### PR TITLE
Support versions of re2 that require C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,17 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
   - ree
   - rbx
 before_install:
-  - wget https://dl.dropbox.com/u/2175127/libre2-dev_20130802_amd64.deb
-  - sudo dpkg -i libre2-dev_20130802_amd64.deb
+  - sudo apt-get install -y clang-3.4
+  - wget https://dl.dropbox.com/u/2175127/$RE2_PACKAGE
+  - sudo dpkg -i $RE2_PACKAGE
   - gem install bundler -v '~> 1.11'
+env:
+  - CC=/usr/bin/clang CXX=/usr/bin/clang++ RE2_PACKAGE=libre2-dev_20160901_amd64.deb
+  - RE2_PACKAGE=libre2-dev_20130802_amd64.deb

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Ruby binding to [re2][], an "efficient, principled regular expression
 library".
 
 **Current version:** 0.7.0  
-**Supported Ruby versions:** 1.8.7, 1.9.2, 1.9.3, 2.0.0, 2.1.0, Rubinius 2.2
+**Supported Ruby versions:** 1.8.7, 1.9.2, 1.9.3, 2.0.0, 2.1.0, 2.2, 2.3, Rubinius 2.2
 
 Installation
 ------------

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -6,8 +6,8 @@
  * Released under the BSD Licence, please see LICENSE.txt
  */
 
-#include <re2/re2.h>
 #include <ruby.h>
+#include <re2/re2.h>
 #include <stdint.h>
 #include <string>
 #include <sstream>


### PR DESCRIPTION
As raised by @stefanor, recent versions of re2 now require a compiler with C++11 support and this gem will fail to compile without the appropriate build flags.

Attempt to detect newer versions and try potential build flags to successfully compile the gem regardless of re2 version.

This also includes a workaround for a bug in Ruby 2.3.0 (fixed in 2.3.1) where memset_s is not included in string.h when using C++11 by requiring Ruby's headers before loading re2.