### PR TITLE
Use CC and CXX from the environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ rvm:
   - 2.2
   - 2.3
   - ree
-  - rbx
+  - rbx-2
+  - rbx-3
 before_install:
   - wget https://dl.dropbox.com/u/2175127/$RE2_PACKAGE
   - sudo dpkg -i $RE2_PACKAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+dist: trusty
+sudo: required
 rvm:
   - 1.8.7
   - 1.9.2
@@ -10,10 +12,9 @@ rvm:
   - ree
   - rbx
 before_install:
-  - sudo apt-get install -y clang-3.4
   - wget https://dl.dropbox.com/u/2175127/$RE2_PACKAGE
   - sudo dpkg -i $RE2_PACKAGE
   - gem install bundler -v '~> 1.11'
 env:
-  - CC=/usr/bin/clang CXX=/usr/bin/clang++ RE2_PACKAGE=libre2-dev_20160901_amd64.deb
+  - RE2_PACKAGE=libre2-dev_20160901_amd64.deb
   - RE2_PACKAGE=libre2-dev_20130802_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
   - 2.2
   - 2.3
   - ree
-  - rbx-2
   - rbx-3
 before_install:
   - wget https://dl.dropbox.com/u/2175127/$RE2_PACKAGE

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    re2 (0.7.0)
+    re2 (1.0.0)
 
 GEM
   remote: http://rubygems.org/
@@ -239,3 +239,6 @@ DEPENDENCIES
   re2!
   rspec (~> 3.2)
   rubysl (~> 2.0)
+
+BUNDLED WITH
+   1.15.1

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -6,6 +6,9 @@
 
 require 'mkmf'
 
+RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"] if ENV["CC"]
+RbConfig::MAKEFILE_CONFIG["CXX"] = ENV["CXX"] if ENV["CXX"]
+
 incl, lib = dir_config("re2", "/usr/local/include", "/usr/local/lib")
 
 $CFLAGS << " -Wall -Wextra -funroll-loops"


### PR DESCRIPTION
GitHub: https://github.com/mudge/re2/issues/33

Follow the lead from Nokogiri and the sqlite3 gem by using the CC (and CXX) environments to configure the Makefile during installation if present.

See:

* https://github.com/sparklemotion/sqlite3-ruby/blob/master/ext/sqlite3/extconf.rb#L7
* https://github.com/sparklemotion/nokogiri/blob/master/ext/nokogiri/extconf.rb#L395-L402