### PR TITLE
Use environment CC and CXX throughout compilation

### DIFF
--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -6,8 +6,15 @@
 
 require 'mkmf'
 
-RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"] if ENV["CC"]
-RbConfig::MAKEFILE_CONFIG["CXX"] = ENV["CXX"] if ENV["CXX"]
+if ENV["CC"]
+  RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"]
+  RbConfig::CONFIG["CC"] = ENV["CC"]
+end
+
+if ENV["CXX"]
+  RbConfig::MAKEFILE_CONFIG["CXX"] = ENV["CXX"]
+  RbConfig::CONFIG["CXX"] = ENV["CXX"]
+end
 
 incl, lib = dir_config("re2", "/usr/local/include", "/usr/local/lib")
 


### PR DESCRIPTION
GitHub: https://github.com/mudge/re2/issues/33

When compiling the gem with a compiler specified through the CC and CXX environment variables, we need to update both the Makefile configuration and standard Ruby configuration so that the various pre-compilation checks and final Makefile use the right compiler toolchain.

This should hopefully allow compilation on OpenBSD using egcc and eg++ (tested in VirtualBox).