### PR TITLE
Test TruffleRuby and Ruby 2.7 support

### DIFF
--- a/.github/actions/test/Dockerfile
+++ b/.github/actions/test/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends \
+    wget ca-certificates autoconf bison build-essential libssl-dev \
+    libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev \
+    libffi-dev libgdbm3 libgdbm-dev libdb-dev && \
+    update-ca-certificates
+
+RUN wget -O - https://github.com/rbenv/ruby-build/archive/v20210119.tar.gz | tar xz && \
+    PREFIX=/usr/local ./ruby-build-20210119/install.sh
+
+ENV LANG=C.UTF-8
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,17 @@
+name: 're2 Test Action'
+description: 'Run re2 test suite against different Rubies and libre2-dev versions'
+inputs:
+  ruby-version:
+    description: 'The version of Ruby to install'
+    required: true
+    default: 'ruby2.6'
+  libre2-dev-url:
+    description: 'The URL of a version of libre2-dev to install'
+    required: true
+    default: 'https://github.com/mudge/re2/releases/download/v1.2.0/libre2-dev_20200501_amd64.deb'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.ruby-version }}
+    - ${{ inputs.libre2-dev-url }}

--- a/.github/actions/test/entrypoint.sh
+++ b/.github/actions/test/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+ruby_version=$1
+libre2_url=$2
+
+# Install libre2-dev
+wget -O libre2-dev.deb "$libre2_url"
+dpkg -i libre2-dev.deb
+
+# Install Ruby
+ruby-build "$ruby_version" "/opt/rubies/${ruby_version}"
+export PATH=/opt/rubies/${ruby_version}/bin:$PATH
+
+# Install dependencies for tests
+gem install bundler -v '~> 1.11'
+bundle install --jobs=2 --retry=3 --deployment
+
+# Run tests
+bundle exec rake

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,23 +10,27 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "ruby1.8"
-          - "ruby1.9.1"
-          - "ruby2.0"
-          - "ruby2.1"
-          - "ruby2.2"
-          - "ruby2.3"
-          - "ruby2.4"
-          - "ruby2.5"
-          - "ruby2.6"
-          - "rbx3.107"
+          - "1.8.7"
+          - "1.9.1-p431"
+          - "2.0.0-p648"
+          - "2.1.10"
+          - "2.2.10"
+          - "2.3.8"
+          - "2.4.10"
+          - "2.5.8"
+          - "2.6.6"
+          - "2.7.2"
+          - "rbx-3.107"
+          - "rbx-4.9"
+          - "rbx-5.0"
+          - "truffleruby-21.0.0"
         libre2:
           - "20130802-1"
           - "20160901-1"
           - "20200501"
     steps:
     - uses: actions/checkout@v2
-    - uses: mudge/re2-test-action@v1
+    - uses: ./.github/actions/test
       with:
         ruby-version: "${{ matrix.ruby }}"
         libre2-dev-url: "https://github.com/mudge/re2-test-action/releases/download/v1/libre2-dev_${{ matrix.libre2 }}_amd64.deb"


### PR DESCRIPTION
Bring the custom re2 test GitHub action into the repository by following https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-action-in-the-same-repository-as-the-workflow, making it easier to manage changes to CI alongside code changes.

By doing so, extend the test action to support versions of TruffleRuby by using the standalone distributions (https://github.com/oracle/truffleruby/blob/master/doc/user/standalone-distribution.md#latest-release).
