### PR TITLE
Search Homebrew's prefix on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ Ruby header files installed such as those provided by the [ruby-dev][] package
 on Debian and Ubuntu.
 
 You can then install the library via RubyGems with `gem install re2` or `gem
-install re2 -- --with-re2-dir=/opt/local/re2` if re2 is not installed in the
-default location of `/usr/local/`.
+install re2 -- --with-re2-dir=/path/to/re2/prefix` if re2 is not installed in
+any of the following default locations:
+
+* `/usr/local`
+* `/opt/homebrew`
+* `/usr`
 
 Documentation
 -------------

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -16,7 +16,19 @@ if ENV["CXX"]
   RbConfig::CONFIG["CXX"] = ENV["CXX"]
 end
 
-incl, lib = dir_config("re2", "/usr/local/include", "/usr/local/lib")
+header_dirs = [
+  "/usr/local/include",
+  "/opt/homebrew/include",
+  "/usr/include"
+]
+
+lib_dirs = [
+  "/usr/local/lib",
+  "/opt/homebrew/lib",
+  "/usr/lib"
+]
+
+dir_config("re2", header_dirs, lib_dirs)
 
 $CFLAGS << " -Wall -Wextra -funroll-loops"
 


### PR DESCRIPTION
GitHub: https://github.com/mudge/re2/issues/50

To make installation easier for users of Homebrew on Apple Silicon, add /opt/homebrew to the default paths searched when trying to find the underlying re2 library.  While doing so, add an extra fallback to /usr (instead of only searching /usr/local).

Note we still search /usr/local first to avoid accidentally changing behaviour for existing users (e.g. suddenly compiling against a different version of re2 in /usr).
