### PR TITLE
Fix crash when using RE2::Scanner#scan with an invalid regular expression

### DIFF
--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -1251,7 +1251,13 @@ static VALUE re2_regexp_scan(VALUE self, VALUE text) {
   c->input = new(nothrow) re2::StringPiece(StringValuePtr(text));
   c->regexp = self;
   c->text = text;
-  c->number_of_capturing_groups = p->pattern->NumberOfCapturingGroups();
+
+  if (p->pattern->ok()) {
+    c->number_of_capturing_groups = p->pattern->NumberOfCapturingGroups();
+  } else {
+    c->number_of_capturing_groups = 0;
+  }
+
   c->eof = false;
 
   return scanner;

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -1158,6 +1158,7 @@ static VALUE re2_regexp_named_capturing_groups(VALUE self) {
  *   @param [String] text the text to search
  *   @param [Fixnum] number_of_matches the number of matches to return
  *   @return [RE2::MatchData] the matches
+ *   @raise [ArgumentError] if given a negative number of matches
  *   @raise [NoMemoryError] if there was not enough memory to allocate the matches
  *   @example
  *     r = RE2::Regexp.new('w(o)(o)')
@@ -1180,7 +1181,15 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, VALUE self) {
 
   if (RTEST(number_of_matches)) {
     n = NUM2INT(number_of_matches);
+
+    if (n < 0) {
+      rb_raise(rb_eArgError, "number of matches should be >= 0");
+    }
   } else {
+    if (!p->pattern->ok()) {
+      return Qnil;
+    }
+
     n = p->pattern->NumberOfCapturingGroups();
   }
 

--- a/spec/re2/regexp_spec.rb
+++ b/spec/re2/regexp_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe RE2::Regexp do
     it "raises an error if given an inappropriate type" do
       expect { RE2::Regexp.new(nil) }.to raise_error(TypeError)
     end
+
+    it "allows invalid patterns to be created" do
+      re = RE2::Regexp.new('???', :log_errors => false)
+      expect(re).to be_a(RE2::Regexp)
+    end
   end
 
   describe "#compile" do
@@ -23,6 +28,11 @@ RSpec.describe RE2::Regexp do
 
     it "returns an instance given a pattern and options" do
       re = RE2::Regexp.compile('woo', :case_sensitive => false)
+      expect(re).to be_a(RE2::Regexp)
+    end
+
+    it "allows invalid patterns to be created" do
+      re = RE2::Regexp.compile('???', :log_errors => false)
       expect(re).to be_a(RE2::Regexp)
     end
   end
@@ -83,6 +93,11 @@ RSpec.describe RE2::Regexp do
       program_size = RE2::Regexp.new('w(o)(o)').program_size
       expect(program_size).to be_a(Fixnum)
     end
+
+    it "returns -1 for an invalid pattern" do
+      program_size = RE2::Regexp.new('???', :log_errors => false).program_size
+      expect(program_size).to eq(-1)
+    end
   end
 
   describe "#to_str" do
@@ -96,6 +111,11 @@ RSpec.describe RE2::Regexp do
     it "returns the original pattern" do
       pattern = RE2::Regexp.new('w(o)(o)').pattern
       expect(pattern).to eq("w(o)(o)")
+    end
+
+    it "returns the pattern even if invalid" do
+      pattern = RE2::Regexp.new('???', :log_errors => false).pattern
+      expect(pattern).to eq("???")
     end
   end
 
@@ -278,6 +298,11 @@ RSpec.describe RE2::Regexp do
       expect { re.match("My name is Robert Paulson", -1) }.to raise_error(ArgumentError, "number of matches should be >= 0")
     end
 
+    it "returns nil with an invalid pattern" do
+      re = RE2::Regexp.new('???', :log_errors => false)
+      expect(re.match('My name is Robert Paulson')).to be_nil
+    end
+
     describe "with a specific number of matches under the total in the pattern" do
       subject { re.match("My name is Robert Paulson", 1) }
 
@@ -328,6 +353,11 @@ RSpec.describe RE2::Regexp do
       re = RE2::Regexp.new('My name is (\S+) (\S+)')
       expect(re.match?("My name is Robert Paulson")).to eq(true)
       expect(re.match?("My age is 99")).to eq(false)
+    end
+
+    it "returns false if the pattern is invalid" do
+      re = RE2::Regexp.new('???', :log_errors => false)
+      expect(re.match?("My name is Robert Paulson")).to eq(false)
     end
   end
 
@@ -387,6 +417,10 @@ RSpec.describe RE2::Regexp do
       expect(RE2::Regexp.new('abc').number_of_capturing_groups).to eq(0)
       expect(RE2::Regexp.new('a((b)c)').number_of_capturing_groups).to eq(2)
     end
+
+    it "returns -1 for an invalid regexp" do
+      expect(RE2::Regexp.new('???', :log_errors => false).number_of_capturing_groups).to eq(-1)
+    end
   end
 
   describe "#named_capturing_groups" do
@@ -403,6 +437,10 @@ RSpec.describe RE2::Regexp do
       groups = RE2::Regexp.new('(?P<bob>a)(o)(?P<rob>e)').named_capturing_groups
       expect(groups["bob"]).to eq(1)
       expect(groups["rob"]).to eq(3)
+    end
+
+    it "returns an empty hash for an invalid regexp" do
+      expect(RE2::Regexp.new('???', :log_errors => false).named_capturing_groups).to be_empty
     end
   end
 

--- a/spec/re2/regexp_spec.rb
+++ b/spec/re2/regexp_spec.rb
@@ -399,13 +399,13 @@ RSpec.describe RE2::Regexp do
     end
   end
 
-  describe "#escape" do
+  describe ".escape" do
     it "transforms a string into a regexp" do
       expect(RE2::Regexp.escape("1.5-2.0?")).to eq('1\.5\-2\.0\?')
     end
   end
 
-  describe "#quote" do
+  describe ".quote" do
     it "transforms a string into a regexp" do
       expect(RE2::Regexp.quote("1.5-2.0?")).to eq('1\.5\-2\.0\?')
     end

--- a/spec/re2/regexp_spec.rb
+++ b/spec/re2/regexp_spec.rb
@@ -274,6 +274,10 @@ RSpec.describe RE2::Regexp do
       expect { re.match("My name is Robert Paulson", {}) }.to raise_error(TypeError)
     end
 
+    it "raises an exception when given a negative number of matches" do
+      expect { re.match("My name is Robert Paulson", -1) }.to raise_error(ArgumentError, "number of matches should be >= 0")
+    end
+
     describe "with a specific number of matches under the total in the pattern" do
       subject { re.match("My name is Robert Paulson", 1) }
 

--- a/spec/re2/scanner_spec.rb
+++ b/spec/re2/scanner_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe RE2::Scanner do
       expect(scanner.scan).to be_nil
     end
 
+    it "returns nil if the regexp is invalid" do
+      r = RE2::Regexp.new('???', :log_errors => false)
+      scanner = r.scan("Foo bar")
+      expect(scanner.scan).to be_nil
+    end
+
     it "returns an empty array if the input is empty" do
       r = RE2::Regexp.new("")
       scanner = r.scan("")


### PR DESCRIPTION
As re2 will report the number of capturing groups for an invalid regular expression as -1, we need to check whether a pattern is OK or not before using the number to initialize any vectors, etc.

This was causing a crash when using `RE2::Scanner#scan` with an invalid regular expression as we would attempt to initialize vectors with a length of -1. Instead, set the number of capturing groups to 0 and rely on re2's `FindAndConsumeN` returning false so we return nil to the user to indicate no match was made.

Following that, ensure we always check a pattern is OK before using its number of capturing groups as a positive integer.

This also fixes an edge case in `RE2::Regexp#match` when a user passes a negative number for the number of intended matches. Previously, this would throw a misleading `NoMemoryError`, now it throws a more informative `ArgumentError`.

Take this opportunity to document the behaviour of the library when given invalid regular expressions in the specs.
