### PR TITLE
Add bindings for RE2::Set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Remove any existing libre2 installation
-        run: sudo apt-get remove -y libre2-dev libre2-1v5
+        run: sudo apt-get remove -y libre2-dev libre2-5
       - name: Download and install specific release of libre2
         run: |
           curl -Lo libre2-dev.deb https://github.com/mudge/re2-ci/releases/download/v2/libre2-dev_${{ matrix.libre2.version }}_amd64.deb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: "mudge/re2-ci:${{ matrix.ruby }}"
-      options: "--add-host rubygems.org:151.101.0.70 --add-host api.rubygems.org:151.101.0.70"
+      options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
     strategy:
       matrix:
         ruby:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   test:
     name: Ruby ${{ matrix.ruby }} - libre2 ABI version ${{ matrix.libre2.soname }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         ruby:
+          - '3.1'
           - '3.0'
           - 2.7
           - 2.6
@@ -38,7 +39,7 @@ jobs:
         run: sudo apt-get remove -y libre2-dev libre2-1v5
       - name: Download and install specific release of libre2
         run: |
-          curl -Lo libre2-dev.deb https://github.com/mudge/re2-ci/releases/download/v1/libre2-dev_${{ matrix.libre2.version }}_amd64.deb
+          curl -Lo libre2-dev.deb https://github.com/mudge/re2-ci/releases/download/v2/libre2-dev_${{ matrix.libre2.version }}_amd64.deb
           sudo dpkg -i libre2-dev.deb
       - uses: ruby/setup-ruby@v1
         with:
@@ -48,7 +49,7 @@ jobs:
 
   legacy:
     name: Legacy Ruby ${{ matrix.ruby }} - libre2 ABI version ${{ matrix.libre2.soname }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     container:
       image: "mudge/re2-ci:${{ matrix.ruby }}"
       options: "--add-host rubygems.org:151.101.0.70 --add-host api.rubygems.org:151.101.0.70"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           - version: "20201101"
             soname: 9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Remove any existing libre2 installation
         run: sudo apt-get remove -y libre2-dev libre2-5
       - name: Download and install specific release of libre2
@@ -73,7 +73,7 @@ jobs:
           - version: "20201101"
             soname: 9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download and install specific release of libre2
         run: |
           curl -Lo libre2-dev.deb https://github.com/mudge/re2-ci/releases/download/v1/libre2-dev_${{ matrix.libre2.version }}_amd64.deb
@@ -83,7 +83,7 @@ jobs:
       - name: Generate Gemfile.lock
         run: bundle lock
       - name: Cache Ruby dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: gems-v1-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}

--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ enum.next #=> ["It"]
 enum.next #=> ["is"]
 ```
 
+On versions later than 1.4.0, you can use `RE2::Set` to match multiple patterns
+against a string. Calling `RE2::Set#add` with a pattern will return an integer
+index of the pattern. After all patterns have been added, the set can be
+compiled using `RE2::Set#compile`, and then `RE2::Set#match` will return an
+`Array<Integer>` containing the indexes of all the patterns that matched.
+
+``` ruby
+set = RE2::Set.new
+set.add("abc") #=> 0
+set.add("def") #=> 1
+set.add("ghi") #=> 2
+set.compile #=> true
+set.match("abcdefghi") #=> [0, 1, 2]
+set.match("ghidefabc") #=> [2, 1, 0]
+```
+
 Features
 --------
 

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -88,4 +88,28 @@ SRC
   end
 end
 
+checking_for("RE2::Set::Match() with error information") do
+  test_re2_set_match_signature = <<SRC
+#include <vector>
+#include <re2/re2.h>
+#include <re2/set.h>
+
+int main() {
+  RE2::Set s(RE2::DefaultOptions, RE2::UNANCHORED);
+  s.Add("foo", NULL);
+  s.Compile();
+
+  std::vector<int> v;
+  RE2::Set::ErrorInfo ei;
+  s.Match("foo", &v, &ei);
+
+  return 0;
+}
+SRC
+
+  if try_compile(test_re2_set_match_signature, compile_options)
+    $defs.push("-DHAVE_ERROR_INFO_ARGUMENT")
+  end
+end
+
 create_makefile("re2")

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -1443,16 +1443,22 @@ static VALUE re2_set_initialize(int argc, VALUE *argv, VALUE self) {
   } else {
     Check_Type(anchor, T_SYMBOL);
     ID id_anchor = SYM2ID(anchor);
-    if (id_anchor == id_unanchored) { re2_anchor = RE2::UNANCHORED; }
-    else if (id_anchor == id_anchor_start) { re2_anchor = RE2::ANCHOR_START; }
-    else if (id_anchor == id_anchor_both) { re2_anchor = RE2::ANCHOR_BOTH; }
-    else {
+    if (id_anchor == id_unanchored) {
+      re2_anchor = RE2::UNANCHORED;
+    } else if (id_anchor == id_anchor_start) {
+      re2_anchor = RE2::ANCHOR_START;
+    } else if (id_anchor == id_anchor_both) {
+      re2_anchor = RE2::ANCHOR_BOTH;
+    } else {
       rb_raise(rb_eArgError, "anchor should be one of: :unanchored, :anchor_start, :anchor_both");
     }
   }
 
   s->set = new(nothrow) RE2::Set(re2_options, re2_anchor);
-  if (s->set == 0) rb_raise(rb_eNoMemError, "not enough memory to allocate RE2::Set object");
+  if (s->set == 0) {
+    rb_raise(rb_eNoMemError, "not enough memory to allocate RE2::Set object");
+  }
+
   return self;
 }
 
@@ -1472,7 +1478,10 @@ static VALUE re2_set_add(VALUE self, VALUE str) {
   re2_set *s;
   Data_Get_Struct(self, re2_set, s);
   int index = s->set->Add(regex, &err);
-  if (index < 0) rb_raise(rb_eArgError, "str rejected by RE2::Set->Add(): %s", err.c_str());
+  if (index < 0) {
+    rb_raise(rb_eArgError, "str rejected by RE2::Set->Add(): %s", err.c_str());
+  }
+
   return INT2FIX(index);
 }
 
@@ -1503,7 +1512,8 @@ static VALUE re2_set_match(VALUE self, VALUE str) {
   VALUE result = rb_ary_new2(v.size());
   if (match_failed) {
     switch (e.kind) {
-      case RE2::Set::kNoError: break;
+      case RE2::Set::kNoError:
+        break;
       case RE2::Set::kNotCompiled:
         rb_raise(re2_eSetMatchError, "#match must not be called before #compile");
         break;
@@ -1516,10 +1526,10 @@ static VALUE re2_set_match(VALUE self, VALUE str) {
       default:  // Just in case a future version of libre2 adds new ErrorKinds
         rb_raise(re2_eSetMatchError, "Unknown RE2::Set::ErrorKind: %d", e.kind);
     }
-  }
-  else {
-    for(size_t i = 0; i < v.size(); i++)
+  } else {
+    for (size_t i = 0; i < v.size(); i++) {
       rb_ary_push(result, INT2FIX(v[i]));
+    }
   }
   return result;
 }

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -107,14 +107,13 @@ static ID id_utf8, id_posix_syntax, id_longest_match, id_log_errors,
           id_perl_classes, id_word_boundary, id_one_line,
           id_unanchored, id_anchor_start, id_anchor_both;
 
-RE2::Options parse_re2_options(VALUE options) {
+void parse_re2_options(RE2::Options& re2_options, VALUE options) {
   if (TYPE(options) != T_HASH) {
     rb_raise(rb_eArgError, "options should be a hash");
   }
   VALUE utf8, posix_syntax, longest_match, log_errors,
         max_mem, literal, never_nl, case_sensitive, perl_classes,
         word_boundary, one_line;
-  RE2::Options re2_options;
 
   utf8 = rb_hash_aref(options, ID2SYM(id_utf8));
   if (!NIL_P(utf8)) {
@@ -170,8 +169,6 @@ RE2::Options parse_re2_options(VALUE options) {
   if (!NIL_P(one_line)) {
     re2_options.set_one_line(RTEST(one_line));
   }
-
-  return re2_options;
 }
 
 void re2_matchdata_mark(re2_matchdata* self) {
@@ -748,7 +745,8 @@ static VALUE re2_regexp_initialize(int argc, VALUE *argv, VALUE self) {
   Data_Get_Struct(self, re2_pattern, p);
 
   if (RTEST(options)) {
-    RE2::Options re2_options = parse_re2_options(options);
+    RE2::Options re2_options;
+    parse_re2_options(re2_options, options);
 
     p->pattern = new(nothrow) RE2(StringValuePtr(pattern), re2_options);
   } else {
@@ -1434,9 +1432,7 @@ static VALUE re2_set_initialize(int argc, VALUE *argv, VALUE self) {
   Data_Get_Struct(self, re2_set, s);
 
   if (RTEST(options)) {
-    re2_options = parse_re2_options(options);
-  } else {
-    re2_options = RE2::DefaultOptions;
+    parse_re2_options(re2_options, options);
   }
   if (NIL_P(anchor)) {
     re2_anchor = RE2::UNANCHORED;

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -1494,6 +1494,17 @@ static VALUE re2_set_compile(VALUE self) {
 }
 
 /*
+ * @return [Bool] whether the underlying re2 outputs error information from Set matches
+ */
+static VALUE re2_set_match_raises_errors_p(VALUE self) {
+#ifdef HAVE_ERROR_INFO_ARGUMENT
+  return Qtrue;
+#else
+  return Qfalse;
+#endif
+}
+
+/*
  * @param [String] str the text to match against
  * @return [Array<Integer>] the indices of matching regexps
  */
@@ -1651,6 +1662,8 @@ void Init_re2(void) {
   rb_define_method(re2_cRegexp, "one_line?",
       RUBY_METHOD_FUNC(re2_regexp_one_line), 0);
 
+  rb_define_singleton_method(re2_cSet, "match_raises_errors?",
+      RUBY_METHOD_FUNC(re2_set_match_raises_errors_p), 0);
   rb_define_method(re2_cSet, "initialize",
       RUBY_METHOD_FUNC(re2_set_initialize), -1);
   rb_define_method(re2_cSet, "add", RUBY_METHOD_FUNC(re2_set_add), 1);

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe RE2::Set do
+
+  # libre2, as of 2022-06-01, in set.cc, does print to stderr (fd 2) even when
+  # :log_errors is false. So we need to temporarily redirect stderr while
+  # running tests that might print to it.
+  def silence_stderr(&blk)
+    null_stream = StringIO.new
+    original_stream = $stderr
+    $stderr = null_stream
+
+    blk.call
+  ensure
+    $stderr = original_stream
+  end
+
+  describe "#initialize" do
+    it "returns an instance given no args" do
+      set = RE2::Set.new
+      expect(set).to be_a(RE2::Set)
+    end
+
+    it "returns an instance given only an anchor" do
+      set = RE2::Set.new(:unanchored)
+      expect(set).to be_a(RE2::Set)
+    end
+
+    it "returns an instance given an anchor and options" do
+      set = RE2::Set.new(:unanchored, :case_sensitive => false)
+      expect(set).to be_a(RE2::Set)
+    end
+
+    it "raises an error if given an inappropriate type" do
+      expect { RE2::Set.new(0) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#add" do
+    it "allows multiple patterns to be added", :aggregate_failures do
+      set = RE2::Set.new
+      expect(set.add("abc")).to eq(0)
+      expect(set.add("def")).to eq(1)
+      expect(set.add("ghi")).to eq(2)
+    end
+
+    it "rejects invalid patterns when added" do
+      set = RE2::Set.new(:unanchored, :log_errors => false)
+      expect { set.add("???") }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error if called after #compile" do
+      set = RE2::Set.new(:unanchored, :log_errors => false)
+      set.add("abc")
+      set.compile
+      silence_stderr do
+        expect { set.add("def") }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "#compile" do
+    it "compiles the set without error" do
+      set = RE2::Set.new
+      set.add("abc")
+      set.add("def")
+      set.add("ghi")
+      expect { set.compile }.not_to raise_error
+    end
+  end
+
+  describe "#match" do
+    it "matches against multiple patterns" do
+      set = RE2::Set.new
+      set.add("abc")
+      set.add("def")
+      set.add("ghi")
+      set.compile
+      matches = set.match("abcdefghi")
+      expect(matches).to eq([0, 1, 2])
+    end
+
+    it "raises an error if called before #compile" do
+      set = RE2::Set.new(:unanchored, :log_errors => false)
+      silence_stderr do
+        expect { set.match("") }.to raise_error(RE2::Set::MatchError)
+      end
+    end
+  end
+end

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -110,6 +110,8 @@ RSpec.describe RE2::Set do
     end
 
     it "raises an error if called before #compile" do
+      pending "Versions of re2 with ABI 0 will only return false here"
+
       set = RE2::Set.new(:unanchored, :log_errors => false)
       silence_stderr do
         expect { set.match("") }.to raise_error(RE2::Set::MatchError)

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -109,12 +109,21 @@ RSpec.describe RE2::Set do
       expect(set.match("abcdefghi")).to eq([0, 1, 2])
     end
 
-    it "raises an error if called before #compile" do
-      pending "Versions of re2 with ABI 0 will only return false here"
+    it "raises an error if called before #compile when match outputs errors" do
+      skip "Underlying RE2::Set::Match does not output error information" unless RE2::Set.match_raises_errors?
 
       set = RE2::Set.new(:unanchored, :log_errors => false)
       silence_stderr do
         expect { set.match("") }.to raise_error(RE2::Set::MatchError)
+      end
+    end
+
+    it "returns an empty array if called before #compile when match does not output errors" do
+      skip "Underlying RE2::Set::Match outputs error information" if RE2::Set.match_raises_errors?
+
+      set = RE2::Set.new(:unanchored, :log_errors => false)
+      silence_stderr do
+        expect(set.match("")).to be_empty
       end
     end
   end

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -34,8 +34,18 @@ RSpec.describe RE2::Set do
       expect(set).to be_a(RE2::Set)
     end
 
-    it "returns an instance given only an anchor" do
+    it "returns an instance given only an anchor of :unanchored" do
       set = RE2::Set.new(:unanchored)
+      expect(set).to be_a(RE2::Set)
+    end
+
+    it "returns an instance given only an anchor of :anchor_start" do
+      set = RE2::Set.new(:anchor_start)
+      expect(set).to be_a(RE2::Set)
+    end
+
+    it "returns an instance given only an anchor of :anchor_both" do
+      set = RE2::Set.new(:anchor_both)
       expect(set).to be_a(RE2::Set)
     end
 
@@ -46,6 +56,13 @@ RSpec.describe RE2::Set do
 
     it "raises an error if given an inappropriate type" do
       expect { RE2::Set.new(0) }.to raise_error(TypeError)
+    end
+
+    it "raises an error if given an invalid anchor" do
+      expect { RE2::Set.new(:not_a_valid_anchor) }.to raise_error(
+        ArgumentError,
+        "anchor should be one of: :unanchored, :anchor_start, :anchor_both"
+      )
     end
   end
 
@@ -59,7 +76,7 @@ RSpec.describe RE2::Set do
 
     it "rejects invalid patterns when added" do
       set = RE2::Set.new(:unanchored, :log_errors => false)
-      expect { set.add("???") }.to raise_error(ArgumentError)
+      expect { set.add("???") }.to raise_error(ArgumentError, /str rejected by RE2::Set->Add()/)
     end
 
     it "raises an error if called after #compile" do
@@ -78,7 +95,7 @@ RSpec.describe RE2::Set do
       set.add("abc")
       set.add("def")
       set.add("ghi")
-      expect { set.compile }.not_to raise_error
+      expect(set.compile).to be_truthy
     end
   end
 
@@ -89,8 +106,7 @@ RSpec.describe RE2::Set do
       set.add("def")
       set.add("ghi")
       set.compile
-      matches = set.match("abcdefghi")
-      expect(matches).to eq([0, 1, 2])
+      expect(set.match("abcdefghi")).to eq([0, 1, 2])
     end
 
     it "raises an error if called before #compile" do

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -3,14 +3,29 @@ RSpec.describe RE2::Set do
   # libre2, as of 2022-06-01, in set.cc, does print to stderr (fd 2) even when
   # :log_errors is false. So we need to temporarily redirect stderr while
   # running tests that might print to it.
-  def silence_stderr(&blk)
-    null_stream = StringIO.new
-    original_stream = $stderr
-    $stderr = null_stream
+  def silence_stderr
+    original_stream = STDERR
 
-    blk.call
+    if File.const_defined?(:NULL)
+      STDERR.reopen(File::NULL)
+    else
+      platform = RUBY_PLATFORM == 'java' ? RbConfig::CONFIG['host_os'] : RUBY_PLATFORM
+
+      case platform
+      when /mswin|mingw/i
+        STDERR.reopen('NUL')
+      when /amiga/i
+        STDERR.reopen('NIL')
+      when /openvms/i
+        STDERR.reopen('NL:')
+      else
+        STDERR.reopen('/dev/null')
+      end
+    end
+
+    yield
   ensure
-    $stderr = original_stream
+    STDERR.reopen(original_stream)
   end
 
   describe "#initialize" do

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -106,10 +106,10 @@ RSpec.describe RE2::Set do
       set.add("def")
       set.add("ghi")
       set.compile
-      expect(set.match("abcdefghi")).to eq([0, 1, 2])
+      expect(set.match("abcdefghi", :exception => false)).to eq([0, 1, 2])
     end
 
-    it "raises an error if called before #compile when match outputs errors" do
+    it "raises an error if called before #compile by default" do
       skip "Underlying RE2::Set::Match does not output error information" unless RE2::Set.match_raises_errors?
 
       set = RE2::Set.new(:unanchored, :log_errors => false)
@@ -118,12 +118,28 @@ RSpec.describe RE2::Set do
       end
     end
 
-    it "returns an empty array if called before #compile when match does not output errors" do
+    it "raises an error if called before #compile when :exception is true" do
+      skip "Underlying RE2::Set::Match does not output error information" unless RE2::Set.match_raises_errors?
+
+      set = RE2::Set.new(:unanchored, :log_errors => false)
+      silence_stderr do
+        expect { set.match("", :exception => true) }.to raise_error(RE2::Set::MatchError)
+      end
+    end
+
+    it "returns an empty array if called before #compile when :exception is false" do
+      set = RE2::Set.new(:unanchored, :log_errors => false)
+      silence_stderr do
+        expect(set.match("", :exception => false)).to be_empty
+      end
+    end
+
+    it "raises an error if :exception is true and re2 does not support it" do
       skip "Underlying RE2::Set::Match outputs error information" if RE2::Set.match_raises_errors?
 
       set = RE2::Set.new(:unanchored, :log_errors => false)
       silence_stderr do
-        expect(set.match("")).to be_empty
+        expect { set.match("", :exception => true) }.to raise_error(RE2::Set::UnsupportedError)
       end
     end
   end


### PR DESCRIPTION
`RE2::Set` allows for matching multiple patterns against a string. It scans the string only once and simultaneously checks for regexp matches against all patterns added to it. It is thus significantly faster than matching each pattern individually, which would require scanning the string once for every pattern.