### PR TITLE
Support pattern matching

### DIFF
--- a/spec/re2/match_data_spec.rb
+++ b/spec/re2/match_data_spec.rb
@@ -255,4 +255,48 @@ RSpec.describe RE2::MatchData do
       expect(md.deconstruct).to eq(['o', 'o', nil])
     end
   end
+
+  describe "#deconstruct_keys" do
+    it "returns all named captures if given nil" do
+      md = RE2::Regexp.new('(?P<numbers>\d+) (?P<letters>[a-zA-Z]+)').match('123 abc')
+
+      expect(md.deconstruct_keys(nil)).to eq(:numbers => '123', :letters => 'abc')
+    end
+
+    it "returns only named captures if given names" do
+      md = RE2::Regexp.new('(?P<numbers>\d+) (?P<letters>[a-zA-Z]+)').match('123 abc')
+
+      expect(md.deconstruct_keys([:numbers])).to eq(:numbers => '123')
+    end
+
+    it "returns named captures up until an invalid name is given" do
+      md = RE2::Regexp.new('(?P<numbers>\d+) (?P<letters>[a-zA-Z]+)').match('123 abc')
+
+      expect(md.deconstruct_keys([:numbers, :punctuation])).to eq(:numbers => '123')
+    end
+
+    it "returns an empty hash if given more capture names than exist" do
+      md = RE2::Regexp.new('(?P<numbers>\d+) (?P<letters>[a-zA-Z]+)').match('123 abc')
+
+      expect(md.deconstruct_keys([:numbers, :letters, :punctuation])).to eq({})
+    end
+
+    it "returns an empty hash if there are no named capturing groups" do
+      md = RE2::Regexp.new('(\d+) ([a-zA-Z]+)').match('123 abc')
+
+      expect(md.deconstruct_keys(nil)).to eq({})
+    end
+
+    it "raises an error if given a non-array of keys" do
+      md = RE2::Regexp.new('(?P<numbers>\d+) (?P<letters>[a-zA-Z]+)').match('123 abc')
+
+      expect { md.deconstruct_keys(0) }.to raise_error(TypeError)
+    end
+
+    it "raises an error if given keys as non-symbols" do
+      md = RE2::Regexp.new('(?P<numbers>\d+) (?P<letters>[a-zA-Z]+)').match('123 abc')
+
+      expect { md.deconstruct_keys([0]) }.to raise_error(TypeError)
+    end
+  end
 end

--- a/spec/re2/match_data_spec.rb
+++ b/spec/re2/match_data_spec.rb
@@ -241,4 +241,18 @@ RSpec.describe RE2::MatchData do
       expect(md.end(:foo)).to be_nil
     end
   end
+
+  describe "#deconstruct" do
+    it "returns all capturing groups" do
+      md = RE2::Regexp.new('w(o)(o)').match('woo')
+
+      expect(md.deconstruct).to eq(['o', 'o'])
+    end
+
+    it "includes optional capturing groups as nil" do
+      md = RE2::Regexp.new('w(.)(.)(.)?').match('woo')
+
+      expect(md.deconstruct).to eq(['o', 'o', nil])
+    end
+  end
 end


### PR DESCRIPTION
GitHub: https://github.com/mudge/re2/issues/57

In order to support pattern matching `RE2::MatchData` objects, implement:

* `RE2::MatchData#deconstruct`
* `RE2::MatchData#deconstruct_keys`
