### PR TITLE
Fix compilation with re2 2023-07-01

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository ppa:savoury1/build-tools
-          sudo apt-get install -y libabsl2206
+          sudo apt-get install -y libabsl-dev
       - name: Download and install specific release of libre2
         run: |
           curl -Lo libre2-dev.deb https://github.com/mudge/re2-ci/releases/download/v2/libre2-dev_${{ matrix.libre2.version }}_amd64.deb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Ruby ${{ matrix.ruby }} - libre2 ABI version ${{ matrix.libre2.soname }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         ruby:
@@ -41,7 +41,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Remove any existing libre2 installation
-        run: sudo apt-get remove -y libre2-dev libre2-9
+        run: sudo apt-get remove -y libre2-dev libre2-5
+      - name: Install Abseil for newer re2 releases
+        run: |
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository ppa:savoury1/build-tools
+          sudo apt-get install -y libabsl2206
       - name: Download and install specific release of libre2
         run: |
           curl -Lo libre2-dev.deb https://github.com/mudge/re2-ci/releases/download/v2/libre2-dev_${{ matrix.libre2.version }}_amd64.deb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Ruby ${{ matrix.ruby }} - libre2 ABI version ${{ matrix.libre2.soname }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby:
@@ -36,6 +36,8 @@ jobs:
             soname: 9
           - version: "20221201"
             soname: 10
+          - version: "20230701"
+            soname: 11
     steps:
       - uses: actions/checkout@v3
       - name: Remove any existing libre2 installation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Remove any existing libre2 installation
-        run: sudo apt-get remove -y libre2-dev libre2-5
+        run: sudo apt-get remove -y libre2-dev libre2-9
       - name: Download and install specific release of libre2
         run: |
           curl -Lo libre2-dev.deb https://github.com/mudge/re2-ci/releases/download/v2/libre2-dev_${{ matrix.libre2.version }}_amd64.deb

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -44,24 +44,35 @@ unless have_library("re2")
   abort "You must have re2 installed and specified with --with-re2-dir, please see https://github.com/google/re2/wiki/Install"
 end
 
-# Recent versions of re2 now require a compiler with C++11 support
-checking_for("re2 requires C++11 compiler") do
+TRY_CXXFLAGS = %w[-std=c++20 -std=c++17 -std=c++11 -std=c++0x]
+
+# Recent versions of re2 depend directly on abseil, which requires a
+# compiler with C++14 support (see
+# https://github.com/abseil/abseil-cpp/issues/1127 and
+# https://github.com/abseil/abseil-cpp/issues/1431). However, the
+# `std=c++14` flag doesn't appear to suffice; we need at least
+# `std=c++17`.
+checking_for("re2 requires a C++14 compiler") do
+  success = false
   minimal_program = <<SRC
 #include <re2/re2.h>
 int main() { return 0; }
 SRC
 
-  unless try_compile(minimal_program, compile_options)
-    if try_compile(minimal_program, compile_options + " -std=c++11")
-      compile_options << " -std=c++11"
-      $CPPFLAGS << " -std=c++11"
-    elsif try_compile(minimal_program, compile_options + " -std=c++0x")
-      compile_options << " -std=c++0x"
-      $CPPFLAGS << " -std=c++0x"
-    else
-      abort "Cannot compile re2 with your compiler: recent versions require C++11 support."
+  if try_compile(minimal_program, compile_options)
+    success = true
+  else
+    TRY_CXXFLAGS.each do |version_flag|
+      if try_compile(minimal_program, compile_options + " #{version_flag}")
+        compile_options << " #{version_flag}"
+        $CPPFLAGS << " #{version_flag}"
+        success = true
+        break
+      end
     end
   end
+
+  abort "Cannot compile re2 with your compiler: recent versions require C++14 support." unless success
 end
 
 # Determine which version of re2 the user has installed.


### PR DESCRIPTION
https://code-review.googlesource.com/c/re2/+/61250 made re2 depend directly on abseil. The latest version of abseil now requires C++14 (https://github.com/abseil/abseil-cpp/issues/1127). However, it seems that supplying `-std=c++14` isn't enough (https://github.com/abseil/abseil-cpp/issues/1431). `-std=c++17` needs to be used at least.

This commit fixes the compilation by trying C++20 and C++17 if the initial compilation fails. This fixes build issues on macOS.