### PR TITLE
Vendor re2 and abseil

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,3 +54,39 @@ jobs:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
       - run: bundle exec rake
+
+  vendor:
+    name: Ruby ${{ matrix.ruby }} - vendored libre2 and abseil
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ruby:
+          - '3.2'
+          - '3.1'
+          - '3.0'
+          - 2.7
+          - 2.6
+          - 2.5
+          - 2.4
+          - 2.3
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y build-essential cmake
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
+          bundler-cache: true
+      - name: Configure Bundler for Ruby dependencies
+        run: bundle config --local path vendor/bundle
+      - name: Generate Gemfile.lock
+        run: bundle lock
+      - name: Cache Ruby dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: gems-v1-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
+      - run: bundle install --jobs 4
+      - run: bundle exec rake compile -- --disable-system-libraries
+      - run: bundle exec rake

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,6 @@ jobs:
           - 2.5
           - 2.4
           - 2.3
-          - 2.2
-          - 2.1.9
         libre2:
           - version: "20150501"
             soname: 0
@@ -55,49 +53,4 @@ jobs:
         with:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
-      - run: bundle exec rake
-
-  legacy:
-    name: Legacy Ruby ${{ matrix.ruby }} - libre2 ABI version ${{ matrix.libre2.soname }}
-    runs-on: ubuntu-20.04
-    container:
-      image: "mudge/re2-ci:${{ matrix.ruby }}"
-      options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
-    strategy:
-      matrix:
-        ruby:
-          - 1.8
-          - 1.9.1
-          - '2.0'
-        libre2:
-          - version: "20150501"
-            soname: 0
-          - version: "20200302"
-            soname: 1
-          - version: "20200303"
-            soname: 6
-          - version: "20200501"
-            soname: 7
-          - version: "20200706"
-            soname: 8
-          - version: "20201101"
-            soname: 9
-          - version: "20221201"
-            soname: 10
-    steps:
-      - uses: actions/checkout@v3
-      - name: Download and install specific release of libre2
-        run: |
-          curl -Lo libre2-dev.deb https://github.com/mudge/re2-ci/releases/download/v1/libre2-dev_${{ matrix.libre2.version }}_amd64.deb
-          dpkg -i libre2-dev.deb
-      - name: Configure Bundler for Ruby dependencies
-        run: bundle config --local path vendor/bundle
-      - name: Generate Gemfile.lock
-        run: bundle lock
-      - name: Cache Ruby dependencies
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: gems-v1-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
-      - run: bundle install --jobs 4
       - run: bundle exec rake

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
+      - run: bundle exec rake compile -- --enable-system-libraries
       - run: bundle exec rake
 
   vendor:

--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ namespace 'gem' do
       RakeCompilerDock.sh <<~SCRIPT, platform: platform, verbose: true
         gem install bundler --no-document &&
         bundle &&
-        CMAKE=#{cmake} bundle exec rake gem:#{platform}:builder MAKE='nice make -j`nproc`'
+        bundle exec rake gem:#{platform}:builder CMAKE=#{cmake}
       SCRIPT
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,17 @@
 require 'rake/extensiontask'
 require 'rspec/core/rake_task'
 
+CLEAN.include FileList['**/*{.o,.so,.dylib,.bundle}'],
+              FileList['**/extconf.h'],
+              FileList['**/Makefile'],
+              FileList['pkg/']
+
+CLOBBER.include FileList['**/tmp'],
+                FileList['**/*.log'],
+                FileList['doc/**'],
+                FileList['tmp/']
+CLOBBER.add("ports/*").exclude(%r{ports/archives$})
+
 Rake::ExtensionTask.new('re2')
 
 RSpec::Core::RakeTask.new(:spec)

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,11 @@ end
 CROSS_RUBY_VERSIONS = %w[3.2.0 3.1.0 3.0.0 2.7.0].join(':')
 CROSS_RUBY_PLATFORMS = %w[
   aarch64-linux
+  arm-linux
   arm64-darwin
+  x64-mingw-ucrt
+  x86-linux
+  x86-mingw32
   x86_64-darwin
   x86_64-linux
 ].freeze
@@ -56,7 +60,14 @@ namespace 'gem' do
     # The Linux x86 image (ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86_64-linux)
     # is based on CentOS 7 and has two versions of cmake installed:
     # a 2.8 version in /usr/bin and a 3.25 in /usr/local/bin. The latter is needed by abseil.
-    cmake = platform == 'x86_64-linux' ? '/usr/local/bin/cmake' : 'cmake'
+    cmake =
+      case platform
+      when 'x86_64-linux', 'x86-linux'
+        '/usr/local/bin/cmake'
+      else
+        'cmake'
+      end
+
     desc "build native gem for #{platform} platform"
     task platform do
       RakeCompilerDock.sh <<~SCRIPT, platform: platform, verbose: true

--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,44 @@ CLOBBER.include FileList['**/tmp'],
                 FileList['tmp/']
 CLOBBER.add("ports/*").exclude(%r{ports/archives$})
 
+RE2_GEM_SPEC = Gem::Specification.load('re2.gemspec')
+
 Rake::ExtensionTask.new('re2')
+
+Gem::PackageTask.new(RE2_GEM_SPEC) do |p|
+  p.need_zip = false
+  p.need_tar = false
+end
 
 RSpec::Core::RakeTask.new(:spec)
 
+def gem_build_path
+  File.join 'pkg', RE2_GEM_SPEC.full_name
+end
+
+def add_file_to_gem(relative_source_path)
+  dest_path = File.join(gem_build_path, relative_source_path)
+  dest_dir = File.dirname(dest_path)
+
+  mkdir_p dest_dir unless Dir.exist?(dest_dir)
+  rm_f dest_path if File.exist?(dest_path)
+  safe_ln relative_source_path, dest_path
+
+  RE2_GEM_SPEC.files << relative_source_path
+end
+
+def add_vendored_libraries
+  dependencies = YAML.load_file(File.join(File.dirname(__FILE__), 'dependencies.yml'))
+  abseil_archive = File.join('ports', 'archives', "#{dependencies['abseil']['version']}.tar.gz")
+  libre2_archive = File.join('ports', 'archives', "re2-#{dependencies['libre2']['version']}.tar.gz")
+
+  add_file_to_gem(abseil_archive)
+  add_file_to_gem(libre2_archive)
+end
+
+task gem_build_path do
+  add_vendored_libraries
+end
+
 task :spec    => :compile
 task :default => :spec
-

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,0 +1,9 @@
+libre2:
+  version: "2023-07-01"
+  sha256: "18cf85922e27fad3ed9c96a27733037da445f35eb1a2744c306a37c6d11e95c4"
+  # sha-256 hash provided in https://github.com/google/re2/releases/download/2023-07-01/re2-2023-07-01.tar.gz
+
+abseil:
+  version: "20230125.3"
+  sha256: 5366d7e7fa7ba0d915014d387b66d0d002c03236448e1ba9ef98122c13b35c36
+  # sha-256 hash provided in https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -114,6 +114,21 @@ def cmake_compile_flags(host)
   ]
 end
 
+# By default, mini_portile2 might add an unnecessary option:
+# https://github.com/flavorjones/mini_portile/blob/5084a2aeab12076f534cf0cabc81a4d5f84b5c25/lib/mini_portile2/mini_portile_cmake.rb#L17
+def delete_cmake_generator_option!(options)
+  indices = []
+
+  options.each_with_index do |element, index|
+    if element == '-G' && index + 1 < options.length
+      indices << index
+      indices << index + 1
+    end
+  end
+
+  indices.reverse_each { |index| options.delete_at(index) }
+end
+
 #
 #  main
 #
@@ -240,6 +255,7 @@ def process_recipe(name, version)
       '-DCMAKE_INSTALL_LIBDIR=lib'
     ]
     recipe.configure_options += cmake_compile_flags(recipe.host)
+    delete_cmake_generator_option!(recipe.configure_options)
 
     yield recipe
 

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -6,6 +6,70 @@
 
 require 'mkmf'
 
+PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+
+REQUIRED_MINI_PORTILE_VERSION = "~> 2.8.2" # keep this version in sync with the one in the gemspec
+
+RE2_HELP_MESSAGE = <<~HELP
+  USAGE: ruby #{$0} [options]
+
+    Flags that are always valid:
+
+      --use-system-libraries
+      --enable-system-libraries
+          Use system libraries instead of building and using the packaged libraries. This is the default.
+
+      --disable-system-libraries
+          Use the packaged libraries, and ignore the system libraries. This overrides `--use-system-libraries`.
+
+    Flags only used when using system libraries:
+
+      Related to re2 library:
+
+        --with-re2-dir=DIRECTORY
+            Look for re2 headers and library in DIRECTORY.
+
+    Environment variables used:
+
+      CC
+          Use this path to invoke the compiler instead of `RbConfig::CONFIG['CC']`
+
+      CPPFLAGS
+          If this string is accepted by the C preprocessor, add it to the flags passed to the C preprocessor
+
+      CFLAGS
+          If this string is accepted by the compiler, add it to the flags passed to the compiler
+
+      LDFLAGS
+          If this string is accepted by the linker, add it to the flags passed to the linker
+
+      LIBS
+          Add this string to the flags passed to the linker
+HELP
+
+#
+#  utility functions
+#
+def config_system_libraries?
+  enable_config("system-libraries", true) do |_, default|
+    arg_config("--use-system-libraries", default)
+  end
+end
+
+def concat_flags(*args)
+  args.compact.join(" ")
+end
+
+def do_help
+  print(RE2_HELP_MESSAGE)
+  exit!(0)
+end
+
+#
+#  main
+#
+do_help if arg_config('--help')
+
 if ENV["CC"]
   RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"]
   RbConfig::CONFIG["CC"] = ENV["CC"]
@@ -16,70 +80,57 @@ if ENV["CXX"]
   RbConfig::CONFIG["CXX"] = ENV["CXX"]
 end
 
-header_dirs = [
-  "/usr/local/include",
-  "/opt/homebrew/include",
-  "/usr/include"
-]
+def build_extension
+  $CFLAGS << " -Wall -Wextra -funroll-loops"
 
-lib_dirs = [
-  "/usr/local/lib",
-  "/opt/homebrew/lib",
-  "/usr/lib"
-]
+  # Pass -x c++ to force gcc to compile the test program
+  # as C++ (as it will end in .c by default).
+  compile_options = "-x c++"
 
-dir_config("re2", header_dirs, lib_dirs)
+  have_library("stdc++")
+  have_header("stdint.h")
+  have_func("rb_str_sublen")
 
-$CFLAGS << " -Wall -Wextra -funroll-loops"
+  unless have_library("re2")
+    abort "You must have re2 installed and specified with --with-re2-dir, please see https://github.com/google/re2/wiki/Install"
+  end
 
-# Pass -x c++ to force gcc to compile the test program
-# as C++ (as it will end in .c by default).
-compile_options = "-x c++"
-
-have_library("stdc++")
-have_header("stdint.h")
-have_func("rb_str_sublen")
-
-unless have_library("re2")
-  abort "You must have re2 installed and specified with --with-re2-dir, please see https://github.com/google/re2/wiki/Install"
-end
-
-minimal_program = <<SRC
+  minimal_program = <<SRC
 #include <re2/re2.h>
 int main() { return 0; }
 SRC
 
-re2_requires_version_flag = checking_for("re2 that requires explicit C++ version flag") do
-  !try_compile(minimal_program, compile_options)
-end
+  re2_requires_version_flag = checking_for("re2 that requires explicit C++ version flag") do
+    !try_compile(minimal_program, compile_options)
+  end
 
-if re2_requires_version_flag
-  # Recent versions of re2 depend directly on abseil, which requires a
-  # compiler with C++14 support (see
-  # https://github.com/abseil/abseil-cpp/issues/1127 and
-  # https://github.com/abseil/abseil-cpp/issues/1431). However, the
-  # `std=c++14` flag doesn't appear to suffice; we need at least
-  # `std=c++17`.
-  abort "Cannot compile re2 with your compiler: recent versions require C++14 support." unless %w[c++20 c++17 c++11 c++0x].any? do |std|
-    checking_for("re2 that compiles with #{std} standard") do
-      if try_compile(minimal_program, compile_options + " -std=#{std}")
-        compile_options << " -std=#{std}"
-        $CPPFLAGS << " -std=#{std}"
+  if re2_requires_version_flag
+    # Recent versions of re2 depend directly on abseil, which requires a
+    # compiler with C++14 support (see
+    # https://github.com/abseil/abseil-cpp/issues/1127 and
+    # https://github.com/abseil/abseil-cpp/issues/1431). However, the
+    # `std=c++14` flag doesn't appear to suffice; we need at least
+    # `std=c++17`.
+    abort "Cannot compile re2 with your compiler: recent versions require C++14 support." unless %w[c++20 c++17 c++11 c++0x].any? do |std|
+      checking_for("re2 that compiles with #{std} standard") do
+        if try_compile(minimal_program, compile_options + " -std=#{std}")
+          compile_options << " -std=#{std}"
+          $CPPFLAGS << " -std=#{std}"
 
-        true
+          true
+        end
       end
     end
   end
-end
 
-# Determine which version of re2 the user has installed.
-# Revision d9f8806c004d added an `endpos` argument to the
-# generic Match() function.
-#
-# To test for this, try to compile a simple program that uses
-# the newer form of Match() and set a flag if it is successful.
-checking_for("RE2::Match() with endpos argument") do
-  test_re2_match_signature = <<SRC
+  # Determine which version of re2 the user has installed.
+  # Revision d9f8806c004d added an `endpos` argument to the
+  # generic Match() function.
+  #
+  # To test for this, try to compile a simple program that uses
+  # the newer form of Match() and set a flag if it is successful.
+  checking_for("RE2::Match() with endpos argument") do
+    test_re2_match_signature = <<SRC
 #include <re2/re2.h>
 
 int main() {
@@ -91,13 +142,13 @@ int main() {
 }
 SRC
 
-  if try_compile(test_re2_match_signature, compile_options)
-    $defs.push("-DHAVE_ENDPOS_ARGUMENT")
+    if try_compile(test_re2_match_signature, compile_options)
+      $defs.push("-DHAVE_ENDPOS_ARGUMENT")
+    end
   end
-end
 
-checking_for("RE2::Set::Match() with error information") do
-  test_re2_set_match_signature = <<SRC
+  checking_for("RE2::Set::Match() with error information") do
+    test_re2_set_match_signature = <<SRC
 #include <vector>
 #include <re2/re2.h>
 #include <re2/set.h>
@@ -115,9 +166,123 @@ int main() {
 }
 SRC
 
-  if try_compile(test_re2_set_match_signature, compile_options)
-    $defs.push("-DHAVE_ERROR_INFO_ARGUMENT")
+    if try_compile(test_re2_set_match_signature, compile_options)
+      $defs.push("-DHAVE_ERROR_INFO_ARGUMENT")
+    end
   end
+end
+
+def process_recipe(name, version)
+  require "rubygems"
+  gem("mini_portile2", REQUIRED_MINI_PORTILE_VERSION) # gemspec is not respected at install time
+  require "mini_portile2"
+  message("Using mini_portile version #{MiniPortile::VERSION}\n")
+
+  MiniPortileCMake.new(name, version).tap do |recipe|
+    recipe.target = File.join(PACKAGE_ROOT_DIR, "ports")
+    recipe.configure_options += [
+      # abseil needs a C++14 compiler
+      '-DCMAKE_CXX_STANDARD=17',
+      # needed for building the C extension shared library with -fPIC
+      '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
+      # ensures pkg-config and installed libraries will be in lib, not lib64
+      '-DCMAKE_INSTALL_LIBDIR=lib'
+    ]
+
+    yield recipe
+
+    checkpoint = "#{recipe.target}/#{recipe.name}-#{recipe.version}-#{recipe.host}.installed"
+
+    if File.exist?(checkpoint)
+      message("Building re2 with a packaged version of #{name}-#{version}.\n")
+    else
+      message(<<~EOM)
+        ---------- IMPORTANT NOTICE ----------
+        Building re2 with a packaged version of #{name}-#{version}.
+        Configuration options: #{recipe.configure_options.shelljoin}
+      EOM
+
+      unless recipe.patch_files.empty?
+        message("The following patches are being applied:\n")
+
+        recipe.patch_files.each do |patch|
+          message("  - %s\n" % File.basename(patch))
+        end
+      end
+
+      recipe.cook
+
+      FileUtils.touch(checkpoint)
+    end
+
+    recipe.activate
+  end
+end
+
+def build_with_system_libraries
+  header_dirs = [
+    "/usr/local/include",
+    "/opt/homebrew/include",
+    "/usr/include"
+  ]
+
+  lib_dirs = [
+    "/usr/local/lib",
+    "/opt/homebrew/lib",
+    "/usr/lib"
+  ]
+
+  dir_config("re2", header_dirs, lib_dirs)
+
+  build_extension
+end
+
+def build_with_vendored_libraries
+  message "Building re2 using packaged libraries.\n"
+
+  require 'yaml'
+  dependencies = YAML.load_file(File.join(PACKAGE_ROOT_DIR, 'dependencies.yml'))
+
+  abseil_recipe = process_recipe('abseil', dependencies['abseil']['version']) do |recipe|
+    recipe.files = [{
+      url: "https://github.com/abseil/abseil-cpp/archive/refs/tags/#{recipe.version}.tar.gz",
+      sha256: dependencies['abseil']['sha256']
+    }]
+    recipe.configure_options += ['-DABSL_PROPAGATE_CXX_STD=ON']
+  end
+
+  re2_recipe = process_recipe('libre2', dependencies['libre2']['version']) do |recipe|
+    recipe.files = [{
+      url: "https://github.com/google/re2/releases/download/#{recipe.version}/re2-#{recipe.version}.tar.gz",
+      sha256: dependencies['libre2']['sha256']
+    }]
+    recipe.configure_options += ["-DCMAKE_PREFIX_PATH=#{abseil_recipe.path}", '-DCMAKE_CXX_FLAGS=-DNDEBUG']
+  end
+
+  pkg_config_paths = [
+    "#{abseil_recipe.path}/lib/pkgconfig",
+    "#{re2_recipe.path}/lib/pkgconfig"
+  ].join(':')
+
+  pkg_config_paths = "#{ENV['PKG_CONFIG_PATH']}:#{pkg_config_paths}" if ENV['PKG_CONFIG_PATH']
+
+  ENV['PKG_CONFIG_PATH'] = pkg_config_paths
+  pc_file = File.join(re2_recipe.path, 'lib', 'pkgconfig', 're2.pc')
+  if pkg_config(pc_file)
+    # See https://bugs.ruby-lang.org/issues/18490, broken in Ruby 3.1 but fixed in Ruby 3.2.
+    flags = xpopen(['pkg-config', '--libs', '--static', pc_file], err: %i[child out], &:read)
+    flags.split.each { |flag| append_ldflags(flag) } if $?.success?
+  else
+    raise 'Please install the `pkg-config` utility!'
+  end
+
+  build_extension
+end
+
+if config_system_libraries?
+  build_with_system_libraries
+else
+  build_with_vendored_libraries
 end
 
 create_makefile("re2")

--- a/lib/re2.rb
+++ b/lib/re2.rb
@@ -3,5 +3,11 @@
 #
 # Copyright (c) 2010-2014, Paul Mucur (http://mudge.name)
 # Released under the BSD Licence, please see LICENSE.txt
-require "re2.so"
+begin
+  ::RUBY_VERSION =~ /(\d+\.\d+)/
+  require_relative "#{Regexp.last_match(1)}/re2.so"
+rescue LoadError
+  require 're2.so'
+end
+
 require "re2/scanner"

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
     "spec/re2/set_spec.rb",
     "spec/re2/scanner_spec.rb"
   ]
-  s.add_development_dependency("rake-compiler", "~> 0.9")
+  s.add_development_dependency "rake-compiler", "~> 1.2.1"
+  s.add_development_dependency "rake-compiler-dock", "~> 1.3.0"
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_runtime_dependency("mini_portile2", "~> 2.8.2") # keep version in sync with extconf.rb
 end

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   ]
   s.add_development_dependency("rake-compiler", "~> 0.9")
   s.add_development_dependency("rspec", "~> 3.2")
+  s.add_runtime_dependency("mini_portile2", "~> 2.8.2") # keep version in sync with extconf.rb
 end


### PR DESCRIPTION
This pull request:

* Vendors re2 and abseil in the Ruby platform gem.
* Builds precompiled native gems for the following platforms:

  - aarch64-linux
  - arm-linux
  - arm64-darwin
  - x64-mingw-ucrt
  - x86-linux
  -  x86-mingw32
  - x86_64-darwin
  - x86_64-linux

* By default, build and link against the vendored re2 and abseil versions. `cmake` and a C++17 compiler is required for this to work. Users can specify `--enable-system-libraries` or set `RE2_USE_SYSTEM_LIBRARIES`.

This makes it possible to ensure all the required dependencies are contained within the C extension rather than depend on system libraries, which may break the extension when they are updated.

The building of these libraries uses mini_portile2 and techniques borrowed from the nokogiri and ruby-magic gems.

glibc 2.29 is required for the arm64 Linux installs.

Closes https://github.com/mudge/re2/issues/61