### PR TITLE
Require Ruby 2.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,7 @@ jobs:
           - '3.2'
           - '3.1'
           - '3.0'
-          - 2.7
-          - 2.6
-          - 2.5
-          - 2.4
-          - 2.3
+          - '2.7'
         libre2:
           - version: "20150501"
             soname: 0
@@ -65,11 +61,7 @@ jobs:
           - '3.2'
           - '3.1'
           - '3.0'
-          - 2.7
-          - 2.6
-          - 2.5
-          - 2.4
-          - 2.3
+          - '2.7'
     steps:
       - uses: actions/checkout@v3
       - name: Install build dependencies

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -68,8 +68,7 @@ def darwin?
 end
 
 def windows?
-  # Use =~ instead of match? to preserve Ruby 2.3 compatibility
-  RbConfig::CONFIG["target_os"] =~ /mingw|mswin/
+  RbConfig::CONFIG["target_os"].match?(/mingw|mswin/)
 end
 
 def freebsd?

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/mudge/re2"
   s.extensions = ["ext/re2/extconf.rb"]
   s.license = "BSD-3-Clause"
+  s.required_ruby_version = ">= 2.7.0"
   s.files = [
     "ext/re2/extconf.rb",
     "ext/re2/re2.cc",


### PR DESCRIPTION
Older versions of Ruby have reached end-of-life. Shipping precompiled gems means that we have to include libraries for all supported versions.

Closes #68