### PR TITLE
Fix Windows gem tests

### DIFF
--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -310,6 +310,7 @@ jobs:
           name: cruby-x64-mingw32-gem
           path: gems
       - run: ./scripts/test-gem-install gems
+        shell: bash
 
   cruby-x64-mingw-ucrt-install:
     needs: ["cruby-native-package"]

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -298,7 +298,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -317,7 +317,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2"]
+        ruby: ["3.1", "3.2"]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The script for installing the package did not actually execute because `pwsh` was loaded instead of `bash`.

As of today, the rake-compiler-dock image for:

1. `mri-x64-mingw-ucrt` only supports Ruby 3.1 and 3.2.
2. `mri-x64-mingw32` only supports Ruby 2.4 - 3.0.