### PR TITLE
Ensure different Windows flavors build their own abseil library

### DIFF
--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -82,6 +82,10 @@ def target_host
   host.gsub(/i386/, "i686")
 end
 
+def target_arch
+  RbConfig::CONFIG['arch']
+end
+
 def with_temp_dir
   Dir.mktmpdir do |temp_dir|
     Dir.chdir(temp_dir) do
@@ -205,7 +209,11 @@ def process_recipe(name, version)
 
   MiniPortileCMake.new(name, version).tap do |recipe|
     recipe.host = target_host
-    recipe.target = File.join(PACKAGE_ROOT_DIR, "ports")
+    target_dir = File.join(PACKAGE_ROOT_DIR, "ports")
+    # Ensure x64-mingw-ucrt and x64-mingw32 use different library paths since the host
+    # is the same (x86_64-w64-mingw32).
+    target_dir = File.join(target_dir, target_arch) if windows? && !target_arch.empty?
+    recipe.target = target_dir
 
     recipe.configure_options += [
       # abseil needs a C++14 compiler


### PR DESCRIPTION
Previously if you ran:

```shell
bundle exec rake gem:x64-mingw-ucrt
bundle exec rake gem:x64-mingw32
```

The latter would fail with undefined symbols:

```shell
linking shared-object re2.so
/usr/bin/x86_64-w64-mingw32-ld: /tmp/re2/ports/x86_64-w64-mingw32/abseil/20230125.3/lib/libabsl_time_zone.a(time_zone_libc.cc.obj):time_zone_libc.cc:(.text+0x97): undefined reference to `__imp___timezone'
/usr/bin/x86_64-w64-mingw32-ld: /tmp/re2/ports/x86_64-w64-mingw32/abseil/20230125.3/lib/libabsl_time_zone.a(time_zone_libc.cc.obj):time_zone_libc.cc:(.text+0xa8): undefined reference to `__imp___dstbias'
/usr/bin/x86_64-w64-mingw32-ld: /tmp/re2/ports/x86_64-w64-mingw32/abseil/20230125.3/lib/libabsl_time_zone.a(time_zone_libc.cc.obj):time_zone_libc.cc:(.text+0xde): undefined reference to `__imp___tzname'
collect2: error: ld returned 1 exit status
make: *** [Makefile:262: re2.so] Error 1
```

The `timezone`, `dstbias`, and `tzname` symbols come from the Microsoft Runtime library.

This happened because the abseil C++ library would be installed for `x64-mingw-ucrt` and `x64-mingw32` in the same directory based on the `host` value (`x86_64-w64-mingw32`). As a result, if `x64-mingw-ucrt` were built first, then the abseil libraries will link against the Universal C Runtime (UCRT). When `rake gem:x64-mingw32` is attempted after `rake gem:x64-mingw-ucrt`, then it will fail to link those symbols because the abseil library in `ports/x86_64-w64-mingw32` directory expects UCRT to be used.

To avoid this mess, append the `RbConfig::CONFIG['arch']` to the mini_portile recipe to ensure `x64-mingw-ucrt` and `x64-mingw32` builds use different library paths.