### PR TITLE
Make it easier to build all gems locally

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -88,7 +88,7 @@ namespace 'gem' do
   end
 
   desc 'build all native gems'
-  task 'native' => CROSS_RUBY_PLATFORMS
+  multitask 'native' => CROSS_RUBY_PLATFORMS
 end
 
 def add_file_to_gem(relative_source_path)

--- a/scripts/build-gems
+++ b/scripts/build-gems
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+#
+#  script to build gems for all relevant platforms
+#
+set -o errexit
+set -o nounset
+set -x
+
+rm -rf tmp pkg gems
+mkdir -p gems
+
+# prelude: let's check that things work
+bundle update
+
+bundle exec rake clean clobber
+bundle exec rake compile
+bundle exec rake spec
+
+# MRI et al (standard gem)
+bundle exec rake clean clobber
+bundle exec rake gem
+cp -v pkg/re2*.gem gems
+
+# precompiled native gems ("fat binary")
+bundle exec rake gem:native
+cp -v pkg/re2*.gem gems
+
+pushd gems
+  ls *.gem | sort | xargs sha256sum
+popd


### PR DESCRIPTION
This pull request does two things:

1. Speeds up building of all the precompiled gems.  rake-compiler by default will attempt to launch N + 4 jobs, where N is the number of cores on the system.
2. Makes it easy to build all gems locally by running `scripts/build-gems`.