### PR TITLE
Fix a few misordered Windows libraries

### DIFF
--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -150,10 +150,11 @@ jobs:
         plat:
           - "aarch64-linux"
           - "arm-linux"
-          - "arm64-darwin"
+          - "arm64-darwin" # github actions does not support this runtime as of 2022-12, but let's build anyway
           - "x64-mingw-ucrt"
           - "x64-mingw32"
           - "x86-linux"
+          - "x86-mingw32" # github actions does not support this runtime as of 2022-12, but let's build anyway
           - "x86_64-darwin"
           - "x86_64-linux"
     runs-on: ubuntu-latest

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -270,6 +270,9 @@ end
 # --libs --static`, resulting in build failures: https://github.com/pkgconf/pkgconf/issues/268.
 # To work around the issue, store the correct order of abseil flags here and add them manually
 # for Windows.
+#
+# Note that `-ldbghelp` is incorrectly added before `-labsl_symbolize` in abseil:
+# https://github.com/abseil/abseil-cpp/issues/1497
 ABSL_LDFLAGS = %w[
   -labsl_flags
   -labsl_flags_internal
@@ -302,6 +305,7 @@ ABSL_LDFLAGS = %w[
   -labsl_graphcycles_internal
   -labsl_stacktrace
   -labsl_symbolize
+  -ldbghelp
   -labsl_debugging_internal
   -labsl_demangle_internal
   -labsl_malloc_internal
@@ -309,6 +313,7 @@ ABSL_LDFLAGS = %w[
   -labsl_civil_time
   -labsl_strings
   -labsl_strings_internal
+  -ladvapi32
   -labsl_base
   -labsl_spinlock_wait
   -labsl_int128


### PR DESCRIPTION
Due to https://github.com/pkgconf/pkgconf/issues/268, we manually worked around Windows link order issues by adding abseil libraries manually. However, a few libraries were missed from that list, which are added only in Windows builds:

* dbghelp
* advapi32

This commit adds these libraries to the right location, which fixes `x86-mingw32` builds.

Note there is an existing issue with abseil including `-ldbghelp` before `-labsl_symbolize`, which this commit corrects: https://github.com/abseil/abseil-cpp/issues/1497