### PR TITLE
Bump version to v2.0.0.beta1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           ruby-version: "3.2"
           bundler-cache: true
-      - run: ./scripts/test-gem-build gems ruby
+      - run: ./scripts/test-gem-build gems ruby ${{github.ref_type}}
       - uses: actions/upload-artifact@v3
         with:
           name: cruby-gem
@@ -205,7 +205,7 @@ jobs:
       - run: |
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             "ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-${{matrix.platform}}" \
-            ./scripts/test-gem-build gems ${{matrix.platform}}
+            ./scripts/test-gem-build gems ${{matrix.platform}} ${{github.ref_type}}
       - uses: actions/upload-artifact@v3
         with:
           name: "cruby-${{matrix.platform}}-gem"

--- a/lib/re2/version.rb
+++ b/lib/re2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RE2
-  VERSION = "1.7.0"
+  VERSION = "2.0.0.beta1"
 end

--- a/scripts/test-gem-build
+++ b/scripts/test-gem-build
@@ -11,13 +11,17 @@ set -e -u
 
 OUTPUT_DIR=$1
 BUILD_NATIVE_GEM=$2
+REF_TYPE=$3
 
 test -e /etc/os-release && cat /etc/os-release
 
 set -x
 
 bundle install --local || bundle install
-bundle exec rake set-version-to-timestamp
+
+if [[ "${REF_TYPE}}" != "tag" ]]; then
+  bundle exec rake set-version-to-timestamp
+fi
 
 if [[ "${BUILD_NATIVE_GEM}" == "ruby" ]] ; then
   # TODO we're only compiling so that we retrieve tarballs, we can do better.


### PR DESCRIPTION
Only call `rake set-version-to-timestamp` if we're on a branch. This will make it possible to build precompiled gems with the right version tag.