### PR TITLE
Drop abseil-cpp build workarounds on Windows

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -4,6 +4,6 @@ libre2:
   # sha-256 hash provided in https://github.com/google/re2/releases/download/2023-07-01/re2-2023-07-01.tar.gz
 
 abseil:
-  version: "20230125.3"
-  sha256: 5366d7e7fa7ba0d915014d387b66d0d002c03236448e1ba9ef98122c13b35c36
-  # sha-256 hash provided in https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz
+  version: "20230802.0"
+  sha256: "59d2976af9d6ecf001a81a35749a6e551a335b949d34918cfade07737b9d93c5"
+  # sha-256 hash provided in https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -288,72 +288,9 @@ def build_with_system_libraries
   build_extension
 end
 
-# pkgconf v1.9.3 on Windows incorrectly sorts the output of `pkg-config
-# --libs --static`, resulting in build failures: https://github.com/pkgconf/pkgconf/issues/268.
-# To work around the issue, store the correct order of abseil flags here and add them manually
-# for Windows.
-#
-# Note that `-ldbghelp` is incorrectly added before `-labsl_symbolize` in abseil:
-# https://github.com/abseil/abseil-cpp/issues/1497
-ABSL_LDFLAGS = %w[
-  -labsl_flags
-  -labsl_flags_internal
-  -labsl_flags_marshalling
-  -labsl_flags_reflection
-  -labsl_flags_private_handle_accessor
-  -labsl_flags_commandlineflag
-  -labsl_flags_commandlineflag_internal
-  -labsl_flags_config
-  -labsl_flags_program_name
-  -labsl_cord
-  -labsl_cordz_info
-  -labsl_cord_internal
-  -labsl_cordz_functions
-  -labsl_cordz_handle
-  -labsl_crc_cord_state
-  -labsl_crc32c
-  -labsl_crc_internal
-  -labsl_crc_cpu_detect
-  -labsl_hash
-  -labsl_city
-  -labsl_bad_variant_access
-  -labsl_low_level_hash
-  -labsl_raw_hash_set
-  -labsl_hashtablez_sampler
-  -labsl_exponential_biased
-  -labsl_bad_optional_access
-  -labsl_str_format_internal
-  -labsl_synchronization
-  -labsl_graphcycles_internal
-  -labsl_stacktrace
-  -labsl_symbolize
-  -ldbghelp
-  -labsl_debugging_internal
-  -labsl_demangle_internal
-  -labsl_malloc_internal
-  -labsl_time
-  -labsl_civil_time
-  -labsl_strings
-  -labsl_strings_internal
-  -ladvapi32
-  -labsl_base
-  -labsl_spinlock_wait
-  -labsl_int128
-  -labsl_throw_delegate
-  -labsl_raw_logging_internal
-  -labsl_log_severity
-  -labsl_time_zone
-].freeze
 
 def add_static_ldflags(flags)
-  static_flags = flags.split
-
-  if MiniPortile.windows?
-    static_flags.each { |flag| append_ldflags(flag) unless ABSL_LDFLAGS.include?(flag) }
-    ABSL_LDFLAGS.each { |flag| append_ldflags(flag) }
-  else
-    static_flags.each { |flag| append_ldflags(flag) }
-  end
+  flags.split.each { |flag| append_ldflags(flag) }
 end
 
 def build_with_vendored_libraries


### PR DESCRIPTION
The linker order problem in https://github.com/abseil/abseil-cpp/issues/1497 was shipped with abseil-cpp 20230802.0, so upgrade to that.

pkgconf v2.0 fixed https://github.com/pkgconf/pkgconf/issues/268, so we should no longer need to add the abseil linker flags manually.