### PR TITLE
Make `rake gem` download source tarballs automatically

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,8 @@ require 'rspec/core/rake_task'
 require 'rake_compiler_dock'
 require 'yaml'
 
+require_relative 'ext/re2/recipes'
+
 CLEAN.include FileList['**/*{.o,.so,.dylib,.bundle}'],
               FileList['**/extconf.h'],
               FileList['**/Makefile'],
@@ -17,6 +19,14 @@ CLOBBER.include FileList['**/tmp'],
 CLOBBER.add("ports/*").exclude(%r{ports/archives$})
 
 RE2_GEM_SPEC = Gem::Specification.load('re2.gemspec')
+
+task :prepare do
+  puts "Preparing project for gem building..."
+  recipes = load_recipes
+  recipes.each { |recipe| recipe.download }
+end
+
+task gem: :prepare
 
 Gem::PackageTask.new(RE2_GEM_SPEC) do |p|
   p.need_zip = false

--- a/ext/re2/recipes.rb
+++ b/ext/re2/recipes.rb
@@ -1,0 +1,43 @@
+PACKAGE_ROOT_DIR = File.expand_path('../..', __dir__)
+REQUIRED_MINI_PORTILE_VERSION = '~> 2.8.4' # keep this version in sync with the one in the gemspec
+
+def build_recipe(name, version)
+  require 'rubygems'
+  gem('mini_portile2', REQUIRED_MINI_PORTILE_VERSION) # gemspec is not respected at install time
+  require 'mini_portile2'
+
+  MiniPortileCMake.new(name, version).tap do |recipe|
+    recipe.target = File.join(PACKAGE_ROOT_DIR, 'ports')
+    recipe.configure_options += [
+      # abseil needs a C++14 compiler
+      '-DCMAKE_CXX_STANDARD=17',
+      # needed for building the C extension shared library with -fPIC
+      '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
+      # ensures pkg-config and installed libraries will be in lib, not lib64
+      '-DCMAKE_INSTALL_LIBDIR=lib'
+    ]
+
+    yield recipe
+  end
+end
+
+def load_recipes
+  require 'yaml'
+  dependencies = YAML.load_file(File.join(PACKAGE_ROOT_DIR, 'dependencies.yml'))
+
+  abseil_recipe = build_recipe('abseil', dependencies['abseil']['version']) do |recipe|
+    recipe.files = [{
+      url: "https://github.com/abseil/abseil-cpp/archive/refs/tags/#{recipe.version}.tar.gz",
+      sha256: dependencies['abseil']['sha256']
+    }]
+  end
+
+  re2_recipe = build_recipe('libre2', dependencies['libre2']['version']) do |recipe|
+    recipe.files = [{
+      url: "https://github.com/google/re2/releases/download/#{recipe.version}/re2-#{recipe.version}.tar.gz",
+      sha256: dependencies['libre2']['sha256']
+    }]
+  end
+
+  [abseil_recipe, re2_recipe]
+end

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
     "dependencies.yml",
     "ext/re2/extconf.rb",
     "ext/re2/re2.cc",
+    "ext/re2/recipes.rb",
     "Gemfile",
     "lib/re2.rb",
     "lib/re2/scanner.rb",

--- a/scripts/test-gem-build
+++ b/scripts/test-gem-build
@@ -20,8 +20,7 @@ bundle install --local || bundle install
 bundle exec rake set-version-to-timestamp
 
 if [[ "${BUILD_NATIVE_GEM}" == "ruby" ]] ; then
-  # TODO we're only compiling so that we retrieve tarballs, we can do better.
-  bundle exec rake clean compile
+  bundle exec rake clean
   bundle exec rake gem
 else
   bundle exec rake gem:${BUILD_NATIVE_GEM}:builder


### PR DESCRIPTION
Previously `scripts/test-gem-build` would call `rake compile` just to make mini_portile2 download the source tarballs. However, this needlessly compiles abseil and libre2 before building the gem.

To improve this, split the loading of the recipes into a separate file (`ext/re2/recipes.rb`). The `rake prepare` step invokes the `download` method to download the required tarballs in preparation for building the gem.

Now we add a `rake prepare` task that will run if `rake gem` is run.