### PR TITLE
Fix typo in scripts/test-gem-build

### DIFF
--- a/lib/re2/version.rb
+++ b/lib/re2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RE2
-  VERSION = "2.0.0.beta1"
+  VERSION = "2.0.0.beta2"
 end

--- a/scripts/test-gem-build
+++ b/scripts/test-gem-build
@@ -19,6 +19,10 @@ set -x
 
 bundle install --local || bundle install
 
+if [[ "${REF_TYPE}" != "tag" ]]; then
+  bundle exec rake set-version-to-timestamp
+fi
+
 if [[ "${BUILD_NATIVE_GEM}" == "ruby" ]] ; then
   bundle exec rake clean
   bundle exec rake gem


### PR DESCRIPTION
This was causing the timestamp to be used in the tagged version.