### PR TITLE
Fix static linking when system libraries installed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,11 @@ on:
 jobs:
   compile-and-test-system-dependencies:
     needs: ["build-cruby-gem"]
-    name: System Dependencies - Ruby ${{ matrix.ruby }} - libre2 ABI version ${{ matrix.libre2.soname }}
+    name: System Dependencies - ${{ matrix.sys }} vendored libs - Ruby ${{ matrix.ruby }} - libre2 ABI version ${{ matrix.libre2.soname }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
+        sys: ["enable", "disable"]
         ruby:
           - '3.2'
           - '3.1'
@@ -62,7 +63,9 @@ jobs:
         with:
           name: cruby-gem
           path: gems
-      - run: ./scripts/test-gem-install gems --enable-system-libraries
+      - name: Add a symlink for libre2
+        run: ln -s /usr/lib/libre2.so `ruby -e "puts RbConfig::CONFIG['exec_prefix']"`/lib/libre2.so
+      - run: ./scripts/test-gem-install gems --${{matrix.sys}}-system-libraries
 
   compile-and-test-vendored-dependencies:
     name: Vendored Dependencies - Ruby ${{ matrix.ruby }} - ${{ matrix.runs-on }}


### PR DESCRIPTION
Ruby's mkmf appears to list `RbConfig::CONFIG['exec_prefix']/lib` first in the search path when building a C extension. If you have libre2 installed in that path, the linker will use that library instead of the vendored library. This causes an undefined symbol error when using the extension:

```shell
/usr/local/bin/ruby: symbol lookup error: /usr/local/bundle/gems/re2-2.0.0.beta1/lib/re2.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
```

This commit does two things to ensure the final shared library is compiled statically with the vendored libraries:

1. For `-L<path>` flags, ensure that any `ports` paths are prioritized just in case there are installed libraries that might take precedence.

2. For `-l<lib>` flags, convert the library to the static library with a full path and substitute the absolute static library.  For example, -lre2 maps to `/path/to/ports/<arch>/libre2/<version>/lib/libre2.a`.
