### PR TITLE
Add Ruby 2.6 support for native gems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
+          - '2.6'
         libre2:
           - version: "20150501"
             soname: 0
@@ -70,8 +71,10 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ["ubuntu-latest", "macos-latest"]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
         include:
+          - ruby: "2.6"
+            runs-on: "windows-2019"
           - ruby: "2.7"
             runs-on: "windows-2019"
           - ruby: "3.0"
@@ -116,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -134,7 +137,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -152,7 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0"]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -220,7 +223,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -241,7 +244,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -281,7 +284,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
@@ -300,7 +303,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -321,7 +324,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -339,7 +342,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -357,7 +360,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{matrix.ruby}}-alpine"

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ Gem::PackageTask.new(RE2_GEM_SPEC) do |p|
   p.need_tar = false
 end
 
-CROSS_RUBY_VERSIONS = %w[3.2.0 3.1.0 3.0.0 2.7.0].join(':')
+CROSS_RUBY_VERSIONS = %w[3.2.0 3.1.0 3.0.0 2.7.0 2.6.0].join(':')
 CROSS_RUBY_PLATFORMS = %w[
   aarch64-linux
   arm-linux

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/mudge/re2"
   s.extensions = ["ext/re2/extconf.rb"]
   s.license = "BSD-3-Clause"
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 2.6.0"
   s.files = [
     ".rspec",
     "dependencies.yml",


### PR DESCRIPTION
As the default system Ruby on macOS Monterey is 2.6 and MiniPortile2 supports back to 2.3, restore support for that Ruby and compile the C extension for it in the native gems.

The trade-off here is that we increase the size of the native gem in order to support more Ruby versions. While 2.6 is technically EOL, the rubygems.org stats still show usage of it in the past month: https://ui.honeycomb.io/ruby-together/datasets/rubygems.org/result/HBSqTboW1yi

(Curiously, those stats show Ruby 2.5 having much higher usage than 2.6 but I think it’s worth making the gem work out of the box on Intel Macs stuck on Monterey.)