### PR TITLE
Upgrade RE2 to 2023-09-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ library".
 
 **Current version:** 2.0.0.beta1  
 **Supported Ruby versions:** 2.7, 3.0, 3.1, 3.2  
-**Bundled re2 version:** libre2.11 (2023-07-01)  
+**Bundled re2 version:** libre2.11 (2023-09-01)  
 **Supported re2 versions:** libre2.0 (< 2020-03-02), libre2.1 (2020-03-02), libre2.6 (2020-03-03), libre2.7 (2020-05-01), libre2.8 (2020-07-06), libre2.9 (2020-11-01), libre2.10 (2022-12-01), libre2.11 (2023-07-01)
 
 Installation

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,7 +1,7 @@
 libre2:
-  version: "2023-07-01"
-  sha256: "18cf85922e27fad3ed9c96a27733037da445f35eb1a2744c306a37c6d11e95c4"
-  # sha-256 hash provided in https://github.com/google/re2/releases/download/2023-07-01/re2-2023-07-01.tar.gz
+  version: "2023-09-01"
+  sha256: "5bb6875ae1cd1e9fedde98018c346db7260655f86fdb8837e3075103acd3649b"
+  # sha-256 hash provided in https://github.com/google/re2/releases/download/2023-09-01/re2-2023-09-01.tar.gz
 
 abseil:
   version: "20230125.3"


### PR DESCRIPTION
Note we're not also upgrading abseil to its latest version (20230802.0) as it drops compatibility for macOS 10.13 and requires workarounds on Windows (see https://github.com/abseil/abseil-cpp/issues/1510).

(See https://github.com/mudge/re2/pull/95 for a PR to also upgrade abseil.)
