### PR TITLE
Add Ruby 2.6 support for native gems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
+          - '2.6'
         libre2:
           - version: "20150501"
             soname: 0
@@ -73,8 +74,10 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ["ubuntu-latest", "macos-latest"]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
         include:
+          - ruby: "2.6"
+            runs-on: "windows-2019"
           - ruby: "2.7"
             runs-on: "windows-2019"
           - ruby: "3.0"
@@ -119,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -137,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -155,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0"]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -223,7 +226,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -244,7 +247,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -284,7 +287,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
@@ -303,7 +306,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -324,7 +327,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -342,7 +345,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -360,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{matrix.ruby}}-alpine"

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ Gem::PackageTask.new(RE2_GEM_SPEC) do |p|
   p.need_tar = false
 end
 
-CROSS_RUBY_VERSIONS = %w[3.2.0 3.1.0 3.0.0 2.7.0].join(':')
+CROSS_RUBY_VERSIONS = %w[3.2.0 3.1.0 3.0.0 2.7.0 2.6.0].join(':')
 CROSS_RUBY_PLATFORMS = %w[
   aarch64-linux
   arm-linux

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -118,7 +118,9 @@ if ENV["CXX"]
 end
 
 def build_extension(static_p = false)
+  # Enable optional warnings but disable deprecated register warning for Ruby 2.6 support
   $CFLAGS << " -Wall -Wextra -funroll-loops"
+  $CPPFLAGS << " -Wno-register"
 
   # Pass -x c++ to force gcc to compile the test program
   # as C++ (as it will end in .c by default).

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/mudge/re2"
   s.extensions = ["ext/re2/extconf.rb"]
   s.license = "BSD-3-Clause"
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 2.6.0"
   s.files = [
     ".rspec",
     "dependencies.yml",


### PR DESCRIPTION
As the default system Ruby on macOS Monterey is 2.6 and MiniPortile2 supports back to 2.3, restore support for that Ruby and compile the C extension for it in the native gems.

The trade-off here is that we increase the size of the native gem in order to support more Ruby versions. While 2.6 is technically EOL, the rubygems.org stats still show usage of it in the past month: https://ui.honeycomb.io/ruby-together/datasets/rubygems.org/result/HBSqTboW1yi

Note Ruby 2.6 triggers a register error with C++17 (it was fixed by https://github.com/ruby/ruby/commit/113bef697633803a33a547914b16ba5fbef165b8 in Ruby 2.7) so we disable that particular error during compilation.
