### PR TITLE
Restore Ruby 2.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
           - '3.0'
           - '2.7'
           - '2.6'
+          - '2.5'
         libre2:
           - version: "20150501"
             soname: 0
@@ -74,8 +75,10 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ["ubuntu-latest", "macos-latest"]
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
         include:
+          - ruby: "2.5"
+            runs-on: "windows-2019"
           - ruby: "2.6"
             runs-on: "windows-2019"
           - ruby: "2.7"
@@ -122,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -140,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -158,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0"]
+        ruby: ["2.5", "2.6", "2.7", "3.0"]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -226,7 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -247,7 +250,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -287,7 +290,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0"]
+        ruby: ["2.5", "2.6", "2.7", "3.0"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
@@ -306,7 +309,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -327,7 +330,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -345,7 +348,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -363,7 +366,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{matrix.ruby}}-alpine"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,8 +242,8 @@ jobs:
       - run: |
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm64/v8 \
-            ruby:${{matrix.ruby}} \
-            ./scripts/test-gem-install ./gems
+            ruby:${{matrix.ruby}}-alpine \
+            ./scripts/test-gem-install-sh ./gems
 
   test-precompiled-arm-linux:
     needs: ["build-precompiled-gems"]
@@ -263,8 +263,8 @@ jobs:
       - run: |
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm/v7 \
-            ruby:${{matrix.ruby}} \
-            ./scripts/test-gem-install ./gems
+            ruby:${{matrix.ruby}}-alpine \
+            ./scripts/test-gem-install-sh ./gems
 
   test-precompiled-x64-mingw-ucrt:
     needs: ["build-precompiled-gems"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Ruby binding to [re2][], an "efficient, principled regular expression
 library".
 
 **Current version:** 2.0.0.beta1  
-**Supported Ruby versions:** 2.7, 3.0, 3.1, 3.2  
+**Supported Ruby versions:** 2.5, 2.6, 2.7, 3.0, 3.1, 3.2  
 **Bundled re2 version:** libre2.11 (2023-09-01)  
 **Supported re2 versions:** libre2.0 (< 2020-03-02), libre2.1 (2020-03-02), libre2.6 (2020-03-03), libre2.7 (2020-05-01), libre2.8 (2020-07-06), libre2.9 (2020-11-01), libre2.10 (2022-12-01), libre2.11 (2023-07-01)
 
@@ -16,7 +16,7 @@ The gem comes bundled with a version of [re2][] and will compile itself (and
 any dependencies) on install. As compilation can take a while, precompiled
 native gems are available for Linux, Windows and macOS.
 
-In v2.0 and later, precompiled native gems are available for Ruby 2.7 to 3.2
+In v2.0 and later, precompiled native gems are available for Ruby 2.5 to 3.2
 on these platforms:
 
 - `aarch64-linux` (requires: glibc >= 2.29)

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ Gem::PackageTask.new(RE2_GEM_SPEC) do |p|
   p.need_tar = false
 end
 
-CROSS_RUBY_VERSIONS = %w[3.2.0 3.1.0 3.0.0 2.7.0 2.6.0].join(':')
+CROSS_RUBY_VERSIONS = %w[3.2.0 3.1.0 3.0.0 2.7.0 2.6.0 2.5.0].join(':')
 CROSS_RUBY_PLATFORMS = %w[
   aarch64-linux
   arm-linux

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/mudge/re2"
   s.extensions = ["ext/re2/extconf.rb"]
   s.license = "BSD-3-Clause"
-  s.required_ruby_version = ">= 2.6.0"
+  s.required_ruby_version = ">= 2.5.0"
   s.files = [
     ".rspec",
     "dependencies.yml",

--- a/scripts/test-gem-install-sh
+++ b/scripts/test-gem-install-sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env sh
+#
+#  run as part of CI
+#
+if [ -f /etc/alpine-release ]; then
+    apk add bash gcompat
+fi
+
+./scripts/test-gem-install $@


### PR DESCRIPTION
While trying to justify the restoration of Ruby 2.6 support by looking at the stats from RubyGems.org, it appears that the third most popular Ruby version is still 2.5. It's not clear why this is but if it is easy for us to add support, this means we cover the top five most used Ruby versions according to https://ui.honeycomb.io/ruby-together/datasets/rubygems.org/result/HBSqTboW1yi (with the bonus of supporting 2.6 due to it being the default system Ruby on macOS Monterey).
