### PR TITLE
Increase test coverage, coerce inputs to string and fix encoding inconsistencies

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,3 @@
---title "RE2: Ruby bindings to re2"
+--title "RE2: Ruby bindings to RE2"
 ext/**/*.cc
 lib/**/*.rb

--- a/LICENSE-DEPENDENCIES.txt
+++ b/LICENSE-DEPENDENCIES.txt
@@ -1,0 +1,237 @@
+# Vendored Dependency Licenses
+
+The library re2 (which lives at https://github.com/mudge/re2) may include the source code for RE2 (which lives at https://github.com/google/re2) and Abseil (which lives at https://abseil.io).
+
+The license terms shipped with RE2 are included here for your convenience:
+
+// Copyright (c) 2009 The RE2 Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The license terms shipped with Abseil are included here for your convenience:
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2014, Paul Mucur.
+Copyright (c) 2010, Paul Mucur.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 re2 [![Build Status](https://github.com/mudge/re2/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/mudge/re2/actions)
 ===
 
-A Ruby binding to [re2][], an "efficient, principled regular expression
-library".
+Ruby bindings to [RE2][], a "fast, safe, thread-friendly alternative to
+backtracking regular expression engines like those used in PCRE, Perl, and
+Python".
 
 **Current version:** 2.0.0  
 **Supported Ruby versions:** 2.6, 2.7, 3.0, 3.1, 3.2  
-**Bundled re2 version:** libre2.11 (2023-09-01)  
-**Supported re2 versions:** libre2.0 (< 2020-03-02), libre2.1 (2020-03-02), libre2.6 (2020-03-03), libre2.7 (2020-05-01), libre2.8 (2020-07-06), libre2.9 (2020-11-01), libre2.10 (2022-12-01), libre2.11 (2023-07-01)
+**Bundled RE2 version:** libre2.11 (2023-09-01)  
+**Supported RE2 versions:** libre2.0 (< 2020-03-02), libre2.1 (2020-03-02), libre2.6 (2020-03-03), libre2.7 (2020-05-01), libre2.8 (2020-07-06), libre2.9 (2020-11-01), libre2.10 (2022-12-01), libre2.11 (2023-07-01)
 
 Installation
 ------------
 
-The gem comes bundled with a version of [re2][] and will compile itself (and
+The gem comes bundled with a version of [RE2][] and will compile itself (and
 any dependencies) on install. As compilation can take a while, precompiled
 native gems are available for Linux, Windows and macOS.
 
@@ -27,10 +28,10 @@ on these platforms:
 - `x86_64-darwin`
 - `x86_64-linux` (requires: glibc >= 2.17)
 
-If you wish to opt out of using the bundled libraries, you will need re2
+If you wish to opt out of using the bundled libraries, you will need RE2
 installed as well as a C++ compiler such as [gcc][] (on Debian and Ubuntu, this
-is provided by the [build-essential][] package). If you are using Mac OS X, I
-recommend installing re2 with [Homebrew][] by running the following:
+is provided by the [build-essential][] package). If you are using macOS, I
+recommend installing RE2 with [Homebrew][] by running the following:
 
     $ brew install re2
 
@@ -38,7 +39,7 @@ If you are using Debian, you can install the [libre2-dev][] package like so:
 
     $ sudo apt-get install libre2-dev
 
-Recent versions of re2 require a compiler with C++14 support such as
+Recent versions of RE2 require a compiler with C++14 support such as
 [clang](http://clang.llvm.org/) 3.4 or [gcc](https://gcc.gnu.org/) 5.
 
 If you are using a packaged Ruby distribution, make sure you also have the
@@ -47,7 +48,7 @@ on Debian and Ubuntu.
 
 You can then install the library via RubyGems with `gem install re2 --platform=ruby --
 --enable-system-libraries` or `gem install re2 --platform=ruby -- --enable-system-libraries
---with-re2-dir=/path/to/re2/prefix` if re2 is not installed in any of the
+--with-re2-dir=/path/to/re2/prefix` if RE2 is not installed in any of the
 following default locations:
 
 * `/usr/local`
@@ -66,7 +67,7 @@ Documentation
 Full documentation automatically generated from the latest version is
 available at <http://mudge.name/re2/>.
 
-Note that re2's regular expression syntax differs from PCRE and Ruby's
+Note that RE2's regular expression syntax differs from PCRE and Ruby's
 built-in [`Regexp`][Regexp] library, see the [official syntax page][] for more
 details.
 
@@ -192,6 +193,24 @@ end
 # My name is Alice and I am 42 years old
 ```
 
+Encoding
+--------
+
+Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+returned in UTF-8 by default or ISO-8859-1 if the `:utf8` option for the
+`RE2::Regexp` is set to false (any other encoding's behaviour is undefined).
+
+For backward compatibility: re2 won't automatically convert string inputs to
+the right encoding so this is the responsibility of the caller, e.g.
+
+```ruby
+# By default, RE2 will process patterns and text as UTF-8
+RE2(non_utf8_pattern.encode("UTF-8")).match(non_utf8_text.encode("UTF-8"))
+
+# If the :utf8 option is false, RE2 will process patterns and text as ISO-8859-1
+RE2(non_latin1_pattern.encode("ISO-8859-1"), :utf8 => false).match(non_latin1_text.encode("ISO-8859-1"))
+```
+
 Features
 --------
 
@@ -238,9 +257,9 @@ Contributions
 * Thanks to [Jason Woods](https://github.com/driskell) who contributed the
   original implementations of `RE2::MatchData#begin` and `RE2::MatchData#end`;
 * Thanks to [Stefano Rivera](https://github.com/stefanor) who first contributed C++11 support;
-* Thanks to [Stan Hu](https://github.com/stanhu) for reporting a bug with empty patterns and `RE2::Regexp#scan`, contributing support for libre2.11 (2023-07-01) and for vendoring re2 and abseil and compiling native gems in 2.0;
+* Thanks to [Stan Hu](https://github.com/stanhu) for reporting a bug with empty patterns and `RE2::Regexp#scan`, contributing support for libre2.11 (2023-07-01) and for vendoring RE2 and abseil and compiling native gems in 2.0;
 * Thanks to [Sebastian Reitenbach](https://github.com/buzzdeee) for reporting
-  the deprecation and removal of the `utf8` encoding option in re2;
+  the deprecation and removal of the `utf8` encoding option in RE2;
 * Thanks to [Sergio Medina](https://github.com/serch) for reporting a bug when
   using `RE2::Scanner#scan` with an invalid regular expression;
 * Thanks to [Pritam Baral](https://github.com/pritambaral) for contributed the
@@ -251,7 +270,7 @@ Contact
 
 All issues and suggestions should go to [GitHub Issues](https://github.com/mudge/re2/issues).
 
-  [re2]: https://github.com/google/re2
+  [RE2]: https://github.com/google/re2
   [gcc]: http://gcc.gnu.org/
   [ruby-dev]: http://packages.debian.org/ruby-dev
   [build-essential]: http://packages.debian.org/build-essential

--- a/README.md
+++ b/README.md
@@ -270,6 +270,18 @@ Contact
 
 All issues and suggestions should go to [GitHub Issues](https://github.com/mudge/re2/issues).
 
+License
+-------
+
+This library is licensed under the BSD 3-Clause License, see `LICENSE.txt`.
+
+Dependencies
+------------
+
+The source code of [RE2][] is distributed in the `ruby` platform gem. This code is licensed under the BSD 3-Clause License, see `LICENSE-DEPENDENCIES.txt`.
+
+The source code of [Abseil][] is distributed in the `ruby` platform gem. This code is licensed under the Apache License 2.0, see `LICENSE-DEPENDENCIES.txt`.
+
   [RE2]: https://github.com/google/re2
   [gcc]: http://gcc.gnu.org/
   [ruby-dev]: http://packages.debian.org/ruby-dev
@@ -279,4 +291,4 @@ All issues and suggestions should go to [GitHub Issues](https://github.com/mudge
   [Homebrew]: http://mxcl.github.com/homebrew
   [libre2-dev]: http://packages.debian.org/search?keywords=libre2-dev
   [official syntax page]: https://github.com/google/re2/wiki/Syntax
-
+  [Abseil]: https://abseil.io

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -648,6 +648,10 @@ static VALUE re2_matchdata_to_s(VALUE self) {
 /*
  * Returns a printable version of the match.
  *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
+ *
  * @return [String] a printable version of the match
  * @example
  *   m = RE2::Regexp.new('(\d+)').match("bob 123")
@@ -876,6 +880,10 @@ static VALUE re2_regexp_initialize(int argc, VALUE *argv, VALUE self) {
 /*
  * Returns a printable version of the regular expression +re2+.
  *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
+ *
  * @return [String] a printable version of the regular expression
  * @example
  *   re2 = RE2::Regexp.new("woo?")
@@ -898,6 +906,10 @@ static VALUE re2_regexp_inspect(VALUE self) {
 
 /*
  * Returns a string version of the regular expression +re2+.
+ *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
  *
  * @return [String] a string version of the regular expression
  * @example
@@ -1126,6 +1138,10 @@ static VALUE re2_regexp_error(VALUE self) {
  * If the RE2 could not be created properly, returns
  * the offending portion of the regexp otherwise returns nil.
  *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
+ *
  * @return [String, nil] the offending portion of the regexp or nil
  */
 static VALUE re2_regexp_error_arg(VALUE self) {
@@ -1221,6 +1237,10 @@ static VALUE re2_regexp_number_of_capturing_groups(VALUE self) {
 
 /*
  * Returns a hash of names to capturing indices of groups.
+ *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
  *
  * @return [Hash] a hash of names to capturing indices
  */

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -39,17 +39,8 @@ using std::vector;
       rb_enc_associate_index(_string, _enc); \
       _string; \
     })
-  #define ENCODED_STR_NEW2(str, length, str2) \
-    ({ \
-      VALUE _string = rb_str_new(str, length); \
-      int _enc = rb_enc_get_index(str2); \
-      rb_enc_associate_index(_string, _enc); \
-      _string; \
-    })
 #else
   #define ENCODED_STR_NEW(str, length, encoding) \
-    rb_str_new((const char *)str, (long)length)
-  #define ENCODED_STR_NEW2(str, length, str2) \
     rb_str_new((const char *)str, (long)length)
 #endif
 
@@ -284,6 +275,10 @@ static VALUE re2_scanner_rewind(VALUE self) {
  * Scan the given text incrementally for matches, returning an array of
  * matches on each subsequent call. Returns nil if no matches are found.
  *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
+ *
  * @return [Array<String>] the matches.
  * @example
  *   s = RE2::Regexp.new('(\w+)').scan("Foo bar baz")
@@ -503,6 +498,10 @@ static VALUE re2_regexp_allocate(VALUE klass) {
 /*
  * Returns the array of matches.
  *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
+ *
  * @return [Array<String, nil>] the array of matches
  * @example
  *   m = RE2::Regexp.new('(\d+)').match("bob 123")
@@ -577,6 +576,10 @@ static VALUE re2_matchdata_named_match(const char* name, VALUE self) {
 
 /*
  * Retrieve zero, one or more matches by index or name.
+ *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
  *
  * @return [Array<String, nil>, String, Boolean]
  *
@@ -689,6 +692,10 @@ static VALUE re2_matchdata_inspect(VALUE self) {
 /*
  * Returns the array of submatches for pattern matching.
  *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
+ *
  * @return [Array<String, nil>] the array of submatches
  * @example
  *   m = RE2::Regexp.new('(\d+)').match("bob 123")
@@ -733,6 +740,10 @@ static VALUE re2_matchdata_deconstruct(VALUE self) {
  * As this is used by Ruby's pattern matching, it will return an empty hash if given
  * more keys than there are capturing groups. Given keys will populate the hash in
  * order but an invalid name will cause the hash to be immediately returned.
+ *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
  *
  * @return [Hash] a hash of capturing group names to submatches
  * @param [Array<Symbol>, nil] keys an array of Symbol capturing group names or nil to return all names
@@ -1389,6 +1400,10 @@ static VALUE re2_regexp_scan(VALUE self, VALUE text) {
  * Returns a copy of +str+ with the first occurrence +pattern+
  * replaced with +rewrite+.
  *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
+ *
  * @param [String] str the string to modify
  * @param [String, RE2::Regexp] pattern a regexp matching text to be replaced
  * @param [String] rewrite the string to replace with
@@ -1419,14 +1434,18 @@ static VALUE re2_Replace(VALUE self, VALUE str, VALUE pattern,
     RE2::Replace(&str_as_string, StringValuePtr(pattern),
         StringValuePtr(rewrite));
 
-    return ENCODED_STR_NEW2(str_as_string.data(), str_as_string.size(),
-        pattern);
+    return ENCODED_STR_NEW(str_as_string.data(), str_as_string.size(),
+        "UTF-8");
   }
 
 }
 
 /*
  * Return a copy of +str+ with +pattern+ replaced by +rewrite+.
+ *
+ * Note RE2 only supports UTF-8 and ISO-8859-1 encoding so strings will be
+ * returned in UTF-8 by default or ISO-8859-1 if the :utf8 option for the
+ * RE2::Regexp is set to false (any other encoding's behaviour is undefined).
  *
  * @param [String] str the string to modify
  * @param [String, RE2::Regexp] pattern a regexp matching text to be replaced
@@ -1458,8 +1477,8 @@ static VALUE re2_GlobalReplace(VALUE self, VALUE str, VALUE pattern,
     RE2::GlobalReplace(&str_as_string, StringValuePtr(pattern),
                        StringValuePtr(rewrite));
 
-    return ENCODED_STR_NEW2(str_as_string.data(), str_as_string.size(),
-        pattern);
+    return ENCODED_STR_NEW(str_as_string.data(), str_as_string.size(),
+        "UTF-8");
   }
 }
 

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -312,7 +312,6 @@ static VALUE re2_scanner_scan(VALUE self) {
   original_input_size = c->input->size();
 
   for (i = 0; i < c->number_of_capturing_groups; i++) {
-    matches[i] = "";
     argv[i] = &matches[i];
     args[i] = &argv[i];
   }
@@ -1404,7 +1403,9 @@ static VALUE re2_Replace(VALUE self, VALUE str, VALUE pattern,
   UNUSED(self);
   re2_pattern *p;
 
-  /* Convert all the inputs to be pumped into RE2::Replace. */
+  /* Take a copy of str so it can be modified in-place by
+   * RE2::Replace.
+   */
   string str_as_string(StringValuePtr(str));
 
   /* Do the replacement. */
@@ -1440,7 +1441,9 @@ static VALUE re2_GlobalReplace(VALUE self, VALUE str, VALUE pattern,
                                VALUE rewrite) {
   UNUSED(self);
 
-  /* Convert all the inputs to be pumped into RE2::GlobalReplace. */
+  /* Take a copy of str so it can be modified in-place by
+   * RE2::GlobalReplace.
+   */
   re2_pattern *p;
   string str_as_string(StringValuePtr(str));
 
@@ -1579,11 +1582,12 @@ static VALUE re2_set_initialize(int argc, VALUE *argv, VALUE self) {
  *   set.add("def")    #=> 1
  */
 static VALUE re2_set_add(VALUE self, VALUE pattern) {
-  Check_Type(pattern, T_STRING);
+  StringValue(pattern);
   re2::StringPiece regex(RSTRING_PTR(pattern), RSTRING_LEN(pattern));
   std::string err;
   re2_set *s;
   Data_Get_Struct(self, re2_set, s);
+
   int index = s->set->Add(regex, &err);
   if (index < 0) {
     rb_raise(rb_eArgError, "str rejected by RE2::Set->Add(): %s", err.c_str());
@@ -1669,7 +1673,8 @@ static VALUE re2_set_match(int argc, VALUE *argv, VALUE self) {
   VALUE str, options, exception_option;
   bool raise_exception = true;
   rb_scan_args(argc, argv, "11", &str, &options);
-  Check_Type(str, T_STRING);
+
+  StringValue(str);
   re2::StringPiece data(RSTRING_PTR(str), RSTRING_LEN(str));
   std::vector<int> v;
   re2_set *s;

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -1252,16 +1252,23 @@ static VALUE re2_regexp_named_capturing_groups(VALUE self) {
  * @return [Boolean, RE2::MatchData]
  *
  * @overload match(text)
- *   Returns an {RE2::MatchData} containing the matching
- *   pattern and all subpatterns resulting from looking for
- *   the regexp in +text+.
+ *   Returns an {RE2::MatchData} containing the matching pattern and all
+ *   subpatterns resulting from looking for the regexp in +text+ if the pattern
+ *   contains capturing groups.
+ *
+ *   Returns either true or false indicating whether a successful match was
+ *   made if the pattern contains no capturing groups.
  *
  *   @param [String] text the text to search
- *   @return [RE2::MatchData] the matches
+ *   @return [RE2::MatchData] if the pattern contains capturing groups
+ *   @return [Boolean] if the pattern does not contain capturing groups
  *   @raise [NoMemoryError] if there was not enough memory to allocate the matches
- *   @example
+ *   @example Matching with capturing groups
  *     r = RE2::Regexp.new('w(o)(o)')
  *     r.match('woo')    #=> #<RE2::MatchData "woo" 1:"o" 2:"o">
+ *   @example Matching without capturing groups
+ *     r = RE2::Regexp.new('woo')
+ *     r.match('woo')    #=> true
  *
  * @overload match(text, 0)
  *   Returns either true or false indicating whether a

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
     "lib/re2/string.rb",
     "lib/re2/version.rb",
     "LICENSE.txt",
+    "LICENSE-DEPENDENCIES.txt",
     "README.md",
     "Rakefile",
     "re2.gemspec"

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -2,8 +2,8 @@ require_relative 'lib/re2/version'
 
 Gem::Specification.new do |s|
   s.name = "re2"
-  s.summary = "Ruby bindings to re2."
-  s.description = 'Ruby bindings to re2, "an efficient, principled regular expression library".'
+  s.summary = "Ruby bindings to RE2."
+  s.description = 'Ruby bindings to RE2, "a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python".'
   s.version = RE2::VERSION
   s.authors = ["Paul Mucur", "Stan Hu"]
   s.homepage = "https://github.com/mudge/re2"
@@ -36,8 +36,8 @@ Gem::Specification.new do |s|
     "spec/re2/set_spec.rb",
     "spec/re2/scanner_spec.rb"
   ]
-  s.add_development_dependency "rake-compiler", "~> 1.2.1"
-  s.add_development_dependency "rake-compiler-dock", "~> 1.3.0"
+  s.add_development_dependency("rake-compiler", "~> 1.2.1")
+  s.add_development_dependency("rake-compiler-dock", "~> 1.3.0")
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_runtime_dependency("mini_portile2", "~> 2.8.4") # keep version in sync with extconf.rb
 end

--- a/spec/kernel_spec.rb
+++ b/spec/kernel_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Kernel do
-  describe "#RE2" do
+  describe ".RE2" do
     it "returns an RE2::Regexp instance given a pattern" do
       expect(RE2('w(o)(o)')).to be_a(RE2::Regexp)
     end
 
     it "returns an RE2::Regexp instance given a pattern and options" do
       re = RE2('w(o)(o)', :case_sensitive => false)
-      expect(re).to be_a(RE2::Regexp)
-      expect(re).to_not be_case_sensitive
+
+      expect(re).not_to be_case_sensitive
     end
   end
 end

--- a/spec/re2/match_data_spec.rb
+++ b/spec/re2/match_data_spec.rb
@@ -10,6 +10,18 @@ RSpec.describe RE2::MatchData do
       a = RE2::Regexp.new('(\d?)(a)(b)').match('ab').to_a
       expect(a).to eq(["ab", nil, "a", "b"])
     end
+
+    it "returns UTF-8 strings if the pattern is UTF-8" do
+      a = RE2::Regexp.new('w(o)(o)').match('woo').to_a
+
+      expect(a.map(&:encoding)).to all eq(Encoding::UTF_8)
+    end
+
+    it "returns ISO-8859-1 strings if the pattern is not UTF-8" do
+      a = RE2::Regexp.new('w(o)(o)', :utf8 => false).match('woo').to_a
+
+      expect(a.map(&:encoding)).to all eq(Encoding::ISO_8859_1)
+    end
   end
 
   describe "#[]" do
@@ -17,6 +29,18 @@ RSpec.describe RE2::MatchData do
       md = RE2::Regexp.new('(\d)(\d{2})').match("123")
       expect(md[1]).to eq("1")
       expect(md[2]).to eq("23")
+    end
+
+    it "returns a UTF-8 string by numerical index if the pattern is UTF-8" do
+      md = RE2::Regexp.new('(\d)(\d{2})').match("123")
+
+      expect(md[1].encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "returns a ISO-8859-1 string by numerical index if the pattern is not UTF-8" do
+      md = RE2::Regexp.new('(\d)(\d{2})', :utf8 => false).match("123")
+
+      expect(md[1].encoding).to eq(Encoding::ISO_8859_1)
     end
 
     it "has the whole match as the 0th item" do

--- a/spec/re2/regexp_spec.rb
+++ b/spec/re2/regexp_spec.rb
@@ -287,6 +287,12 @@ RSpec.describe RE2::Regexp do
       expect(re.match("My age is 99", 0)).to eq(false)
     end
 
+    it "returns only true or false if the pattern has no capturing groups" do
+      re = RE2::Regexp.new('My name is')
+
+      expect(re.match('My name is Robert Paulson')).to eq(true)
+    end
+
     it "raises an exception when given nil" do
       expect { re.match(nil) }.to raise_error(TypeError)
     end

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -67,10 +67,16 @@ RSpec.describe RE2::Set do
       end
     end
 
-    it "raises an error if given a non-string pattern" do
+    it "raises an error if given a pattern that can't be coerced to a String" do
       set = RE2::Set.new(:unanchored, :log_errors => false)
 
       expect { set.add(0) }.to raise_error(TypeError)
+    end
+
+    it "accepts a pattern that can be coerced to a String" do
+      set = RE2::Set.new
+
+      expect(set.add(StringLike.new("abc"))).to eq(0)
     end
   end
 
@@ -94,6 +100,24 @@ RSpec.describe RE2::Set do
       set.compile
 
       expect(set.match("abcdefghi", :exception => false)).to eq([0, 1, 2])
+    end
+
+    it "returns an empty array if there is no match" do
+      set = RE2::Set.new
+      set.add("abc")
+      set.compile
+
+      expect(set.match("def", :exception => false)).to be_empty
+    end
+
+    it "returns an empty array if there is no match when :exception is true" do
+      skip "Underlying RE2::Set::Match does not output error information" unless RE2::Set.match_raises_errors?
+
+      set = RE2::Set.new
+      set.add("abc")
+      set.compile
+
+      expect(set.match("def")).to be_empty
     end
 
     it "raises an error if called before #compile by default" do
@@ -138,6 +162,22 @@ RSpec.describe RE2::Set do
       set = RE2::Set.new
 
       expect { set.match("", 0) }.to raise_error(TypeError)
+    end
+
+    it "raises a Type Error if given input that can't be coerced to a String" do
+      set = RE2::Set.new
+      set.add("abc")
+      set.compile
+
+      expect { set.match(0, :exception => false) }.to raise_error(TypeError)
+    end
+
+    it "accepts input if it can be coerced to a String" do
+      set = RE2::Set.new
+      set.add("abc")
+      set.compile
+
+      expect(set.match(StringLike.new("abcdef"), :exception => false)).to contain_exactly(0)
     end
   end
 

--- a/spec/re2/string_spec.rb
+++ b/spec/re2/string_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe RE2::String do
 
     it "doesn't perform an in-place replacement" do
       string = "My name is Robert Paulson"
-      expect(string.re2_sub('Robert', 'Crobert')).to_not equal(string)
+
+      expect(string.re2_sub('Robert', 'Crobert')).not_to equal(string)
     end
   end
 
@@ -23,13 +24,15 @@ RSpec.describe RE2::String do
 
     it "doesn't perform an in-place replacement" do
       string = "My name is Robert Paulson"
-      expect(string.re2_gsub('a', 'e')).to_not equal(string)
+
+      expect(string.re2_gsub('a', 'e')).not_to equal(string)
     end
   end
 
   describe "#re2_match" do
-    it "delegates to RE2::Regexp#match to perform matches" do
+    it "delegates to RE2::Regexp#match to perform matches", :aggregate_failures do
       md = "My name is Robert Paulson".re2_match('My name is (\S+) (\S+)')
+
       expect(md).to be_a(RE2::MatchData)
       expect(md[0]).to eq("My name is Robert Paulson")
       expect(md[1]).to eq("Robert")
@@ -38,6 +41,7 @@ RSpec.describe RE2::String do
 
     it "supports limiting the number of matches" do
       md = "My name is Robert Paulson".re2_match('My name is (\S+) (\S+)', 0)
+
       expect(md).to eq(true)
     end
   end

--- a/spec/re2_spec.rb
+++ b/spec/re2_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe RE2 do
-  describe "#Replace" do
+  describe ".Replace" do
     it "only replaces the first occurrence of the pattern" do
       expect(RE2.Replace("woo", "o", "a")).to eq("wao")
     end
@@ -15,29 +15,68 @@ RSpec.describe RE2 do
     it "does not perform replacements in-place" do
       name = "Robert"
       replacement = RE2.Replace(name, "R", "Cr")
-      expect(name).to_not equal(replacement)
+
+      expect(name).not_to equal(replacement)
     end
 
     it "supports passing an RE2::Regexp as the pattern" do
       re = RE2::Regexp.new('wo{2}')
+
       expect(RE2.Replace("woo", re, "miaow")).to eq("miaow")
     end
 
     it "respects any passed RE2::Regexp's flags" do
       re = RE2::Regexp.new('gOOD MORNING', :case_sensitive => false)
+
       expect(RE2.Replace("Good morning", re, "hi")).to eq("hi")
     end
 
-    if String.method_defined?(:encoding)
-      it "preserves the original string's encoding" do
-        original = "Foo"
-        replacement = RE2.Replace(original, "oo", "ah")
-        expect(original.encoding).to eq(replacement.encoding)
-      end
+    it "supports passing something that can be coerced to a String as input" do
+      expect(RE2.Replace(StringLike.new("woo"), "oo", "ah")).to eq("wah")
+    end
+
+    it "supports passing something that can be coerced to a String as a pattern" do
+      expect(RE2.Replace("woo", StringLike.new("oo"), "ah")).to eq("wah")
+    end
+
+    it "supports passing something that can be coerced to a String as a replacement" do
+      expect(RE2.Replace("woo", "oo", StringLike.new("ah"))).to eq("wah")
+    end
+
+    it "returns UTF-8 strings if the pattern is UTF-8" do
+      original = "Foo".encode("Shift_JIS")
+      replacement = RE2.Replace(original, "oo", "ah")
+
+      expect(replacement.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "returns ISO-8859-1 strings if the pattern is not UTF-8" do
+      original = "Foo".encode("Shift_JIS")
+      replacement = RE2.Replace(original, RE2("oo", :utf8 => false), "ah")
+
+      expect(replacement.encoding).to eq(Encoding::ISO_8859_1)
+    end
+
+    it "returns strings in the encoding of the given String pattern" do
+      replacement = RE2.Replace("Foo", "oo".encode("Shift_JIS"), "ah")
+
+      expect(replacement.encoding).to eq(Encoding::Shift_JIS)
+    end
+
+    it "raises a Type Error for input that can't be converted to String" do
+      expect { RE2.Replace(0, "oo", "ah") }.to raise_error(TypeError)
+    end
+
+    it "raises a Type Error for a non-RE2::Regexp pattern that can't be converted to String" do
+      expect { RE2.Replace("woo", 0, "ah") }.to raise_error(TypeError)
+    end
+
+    it "raises a Type Error for a replacement that can't be converted to String" do
+      expect { RE2.Replace("woo", "oo", 0) }.to raise_error(TypeError)
     end
   end
 
-  describe "#GlobalReplace" do
+  describe ".GlobalReplace" do
     it "replaces every occurrence of a pattern" do
       expect(RE2.GlobalReplace("woo", "o", "a")).to eq("waa")
     end
@@ -53,23 +92,78 @@ RSpec.describe RE2 do
     it "does not perform replacement in-place" do
       name = "Robert"
       replacement = RE2.GlobalReplace(name, "(?i)R", "w")
-      expect(name).to_not equal(replacement)
+
+      expect(name).not_to equal(replacement)
     end
 
     it "supports passing an RE2::Regexp as the pattern" do
       re = RE2::Regexp.new('wo{2,}')
+
       expect(RE2.GlobalReplace("woowooo", re, "miaow")).to eq("miaowmiaow")
     end
 
     it "respects any passed RE2::Regexp's flags" do
       re = RE2::Regexp.new('gOOD MORNING', :case_sensitive => false)
+
       expect(RE2.GlobalReplace("Good morning Good morning", re, "hi")).to eq("hi hi")
+    end
+
+    it "supports passing something that can be coerced to a String as input" do
+      expect(RE2.GlobalReplace(StringLike.new("woo"), "o", "a")).to eq("waa")
+    end
+
+    it "supports passing something that can be coerced to a String as a pattern" do
+      expect(RE2.GlobalReplace("woo", StringLike.new("o"), "a")).to eq("waa")
+    end
+
+    it "supports passing something that can be coerced to a String as a replacement" do
+      expect(RE2.GlobalReplace("woo", "o", StringLike.new("a"))).to eq("waa")
+    end
+
+    it "returns UTF-8 strings if the pattern is UTF-8" do
+      original = "Foo".encode("Shift_JIS")
+      replacement = RE2.GlobalReplace(original, "oo", "ah")
+
+      expect(replacement.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "returns ISO-8859-1 strings if the pattern is not UTF-8" do
+      original = "Foo".encode("Shift_JIS")
+      replacement = RE2.GlobalReplace(original, RE2("oo", :utf8 => false), "ah")
+
+      expect(replacement.encoding).to eq(Encoding::ISO_8859_1)
+    end
+
+    it "returns strings in the encoding of the given String pattern" do
+      replacement = RE2.GlobalReplace("Foo", "oo".encode("Shift_JIS"), "ah")
+
+      expect(replacement.encoding).to eq(Encoding::Shift_JIS)
+    end
+
+    it "raises a Type Error for input that can't be converted to String" do
+      expect { RE2.GlobalReplace(0, "o", "a") }.to raise_error(TypeError)
+    end
+
+    it "raises a Type Error for a non-RE2::Regexp pattern that can't be converted to String" do
+      expect { RE2.GlobalReplace("woo", 0, "a") }.to raise_error(TypeError)
+    end
+
+    it "raises a Type Error for a replacement that can't be converted to String" do
+      expect { RE2.GlobalReplace("woo", "o", 0) }.to raise_error(TypeError)
     end
   end
 
   describe "#QuoteMeta" do
     it "escapes a string so it can be used as a regular expression" do
       expect(RE2.QuoteMeta("1.5-2.0?")).to eq('1\.5\-2\.0\?')
+    end
+
+    it "raises a Type Error for input that can't be converted to String" do
+      expect { RE2.QuoteMeta(0) }.to raise_error(TypeError)
+    end
+
+    it "supports passing something that can be coerced to a String as input" do
+      expect(RE2.QuoteMeta(StringLike.new("1.5"))).to eq('1\.5')
     end
   end
 end

--- a/spec/re2_spec.rb
+++ b/spec/re2_spec.rb
@@ -44,23 +44,23 @@ RSpec.describe RE2 do
     end
 
     it "returns UTF-8 strings if the pattern is UTF-8" do
-      original = "Foo".encode("Shift_JIS")
+      original = "Foo".encode("ISO-8859-1")
       replacement = RE2.Replace(original, "oo", "ah")
 
       expect(replacement.encoding).to eq(Encoding::UTF_8)
     end
 
     it "returns ISO-8859-1 strings if the pattern is not UTF-8" do
-      original = "Foo".encode("Shift_JIS")
+      original = "Foo"
       replacement = RE2.Replace(original, RE2("oo", :utf8 => false), "ah")
 
       expect(replacement.encoding).to eq(Encoding::ISO_8859_1)
     end
 
-    it "returns strings in the encoding of the given String pattern" do
-      replacement = RE2.Replace("Foo", "oo".encode("Shift_JIS"), "ah")
+    it "returns UTF-8 strings when given a String pattern" do
+      replacement = RE2.Replace("Foo", "oo".encode("ISO-8859-1"), "ah")
 
-      expect(replacement.encoding).to eq(Encoding::Shift_JIS)
+      expect(replacement.encoding).to eq(Encoding::UTF_8)
     end
 
     it "raises a Type Error for input that can't be converted to String" do
@@ -121,23 +121,23 @@ RSpec.describe RE2 do
     end
 
     it "returns UTF-8 strings if the pattern is UTF-8" do
-      original = "Foo".encode("Shift_JIS")
+      original = "Foo".encode("ISO-8859-1")
       replacement = RE2.GlobalReplace(original, "oo", "ah")
 
       expect(replacement.encoding).to eq(Encoding::UTF_8)
     end
 
     it "returns ISO-8859-1 strings if the pattern is not UTF-8" do
-      original = "Foo".encode("Shift_JIS")
+      original = "Foo"
       replacement = RE2.GlobalReplace(original, RE2("oo", :utf8 => false), "ah")
 
       expect(replacement.encoding).to eq(Encoding::ISO_8859_1)
     end
 
-    it "returns strings in the encoding of the given String pattern" do
-      replacement = RE2.GlobalReplace("Foo", "oo".encode("Shift_JIS"), "ah")
+    it "returns UTF-8 strings when given a String pattern" do
+      replacement = RE2.GlobalReplace("Foo", "oo".encode("ISO-8859-1"), "ah")
 
-      expect(replacement.encoding).to eq(Encoding::Shift_JIS)
+      expect(replacement.encoding).to eq(Encoding::UTF_8)
     end
 
     it "raises a Type Error for input that can't be converted to String" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,15 @@
 require "re2"
 
+# To test passing objects that can be coerced to a String.
+class StringLike
+  attr_reader :str
+  alias_method :to_str, :str
+
+  def initialize(str)
+    @str = str
+  end
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Where possible, coerce inputs to strings with StringValue rather than raising a TypeError. This particularly impacts the relatively recent RE2::Set API which was excessively strict about its arguments.

Add test coverage to all parts of the API, better covering edge cases including how encoding is handled based on the encoding of the RE2 pattern.
