### PR TITLE
Assorted C++ cleanup

### DIFF
--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -128,7 +128,6 @@ def build_extension(static_p = false)
 
   have_library("stdc++")
   have_header("stdint.h")
-  have_func("rb_str_sublen")
 
   if !static_p and !have_library("re2")
     abort "You must have re2 installed and specified with --with-re2-dir, please see https://github.com/google/re2/wiki/Install"

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -377,12 +377,10 @@ static VALUE re2_matchdata_size(const VALUE self) {
  */
 static VALUE re2_matchdata_begin(const VALUE self, VALUE n) {
   re2_matchdata *m;
-  re2_pattern *p;
   re2::StringPiece *match;
   long offset;
 
   Data_Get_Struct(self, re2_matchdata, m);
-  Data_Get_Struct(m->regexp, re2_pattern, p);
 
   match = re2_matchdata_find_match(n, self);
   if (match == NULL) {
@@ -406,12 +404,10 @@ static VALUE re2_matchdata_begin(const VALUE self, VALUE n) {
  */
 static VALUE re2_matchdata_end(const VALUE self, VALUE n) {
   re2_matchdata *m;
-  re2_pattern *p;
   re2::StringPiece *match;
   long offset;
 
   Data_Get_Struct(self, re2_matchdata, m);
-  Data_Get_Struct(m->regexp, re2_pattern, p);
 
   match = re2_matchdata_find_match(n, self);
 

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -65,7 +65,7 @@ static ID id_utf8, id_posix_syntax, id_longest_match, id_log_errors,
           id_perl_classes, id_word_boundary, id_one_line,
           id_unanchored, id_anchor_start, id_anchor_both, id_exception;
 
-void parse_re2_options(RE2::Options& re2_options, VALUE options) {
+static void parse_re2_options(RE2::Options* re2_options, const VALUE options) {
   if (TYPE(options) != T_HASH) {
     rb_raise(rb_eArgError, "options should be a hash");
   }
@@ -75,57 +75,57 @@ void parse_re2_options(RE2::Options& re2_options, VALUE options) {
 
   utf8 = rb_hash_aref(options, ID2SYM(id_utf8));
   if (!NIL_P(utf8)) {
-    re2_options.set_encoding(RTEST(utf8) ? RE2::Options::EncodingUTF8 : RE2::Options::EncodingLatin1);
+    re2_options->set_encoding(RTEST(utf8) ? RE2::Options::EncodingUTF8 : RE2::Options::EncodingLatin1);
   }
 
   posix_syntax = rb_hash_aref(options, ID2SYM(id_posix_syntax));
   if (!NIL_P(posix_syntax)) {
-    re2_options.set_posix_syntax(RTEST(posix_syntax));
+    re2_options->set_posix_syntax(RTEST(posix_syntax));
   }
 
   longest_match = rb_hash_aref(options, ID2SYM(id_longest_match));
   if (!NIL_P(longest_match)) {
-    re2_options.set_longest_match(RTEST(longest_match));
+    re2_options->set_longest_match(RTEST(longest_match));
   }
 
   log_errors = rb_hash_aref(options, ID2SYM(id_log_errors));
   if (!NIL_P(log_errors)) {
-    re2_options.set_log_errors(RTEST(log_errors));
+    re2_options->set_log_errors(RTEST(log_errors));
   }
 
   max_mem = rb_hash_aref(options, ID2SYM(id_max_mem));
   if (!NIL_P(max_mem)) {
-    re2_options.set_max_mem(NUM2INT(max_mem));
+    re2_options->set_max_mem(NUM2INT(max_mem));
   }
 
   literal = rb_hash_aref(options, ID2SYM(id_literal));
   if (!NIL_P(literal)) {
-    re2_options.set_literal(RTEST(literal));
+    re2_options->set_literal(RTEST(literal));
   }
 
   never_nl = rb_hash_aref(options, ID2SYM(id_never_nl));
   if (!NIL_P(never_nl)) {
-    re2_options.set_never_nl(RTEST(never_nl));
+    re2_options->set_never_nl(RTEST(never_nl));
   }
 
   case_sensitive = rb_hash_aref(options, ID2SYM(id_case_sensitive));
   if (!NIL_P(case_sensitive)) {
-    re2_options.set_case_sensitive(RTEST(case_sensitive));
+    re2_options->set_case_sensitive(RTEST(case_sensitive));
   }
 
   perl_classes = rb_hash_aref(options, ID2SYM(id_perl_classes));
   if (!NIL_P(perl_classes)) {
-    re2_options.set_perl_classes(RTEST(perl_classes));
+    re2_options->set_perl_classes(RTEST(perl_classes));
   }
 
   word_boundary = rb_hash_aref(options, ID2SYM(id_word_boundary));
   if (!NIL_P(word_boundary)) {
-    re2_options.set_word_boundary(RTEST(word_boundary));
+    re2_options->set_word_boundary(RTEST(word_boundary));
   }
 
   one_line = rb_hash_aref(options, ID2SYM(id_one_line));
   if (!NIL_P(one_line)) {
-    re2_options.set_one_line(RTEST(one_line));
+    re2_options->set_one_line(RTEST(one_line));
   }
 }
 
@@ -824,7 +824,7 @@ static VALUE re2_regexp_initialize(int argc, VALUE *argv, VALUE self) {
 
   if (RTEST(options)) {
     RE2::Options re2_options;
-    parse_re2_options(re2_options, options);
+    parse_re2_options(&re2_options, options);
 
     p->pattern = new(std::nothrow) RE2(StringValuePtr(pattern), re2_options);
   } else {
@@ -1548,7 +1548,7 @@ static VALUE re2_set_initialize(int argc, VALUE *argv, VALUE self) {
   Data_Get_Struct(self, re2_set, s);
 
   if (RTEST(options)) {
-    parse_re2_options(re2_options, options);
+    parse_re2_options(&re2_options, options);
   }
   if (NIL_P(anchor)) {
     re2_anchor = RE2::UNANCHORED;

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -315,7 +315,6 @@ static re2::StringPiece *re2_matchdata_find_match(VALUE idx, const VALUE self) {
   int id;
   re2_matchdata *m;
   re2_pattern *p;
-  std::string name;
   re2::StringPiece *match;
 
   Data_Get_Struct(self, re2_matchdata, m);
@@ -324,6 +323,8 @@ static re2::StringPiece *re2_matchdata_find_match(VALUE idx, const VALUE self) {
   if (FIXNUM_P(idx)) {
     id = FIX2INT(idx);
   } else {
+    const char *name;
+
     if (SYMBOL_P(idx)) {
       name = rb_id2name(SYM2ID(idx));
     } else {
@@ -522,14 +523,13 @@ static VALUE re2_matchdata_named_match(const char* name, const VALUE self) {
   int idx;
   re2_matchdata *m;
   re2_pattern *p;
-  std::string name_as_string(name);
 
   Data_Get_Struct(self, re2_matchdata, m);
   Data_Get_Struct(m->regexp, re2_pattern, p);
 
   const std::map<std::string, int>& groups = p->pattern->NamedCapturingGroups();
 
-  if (std::map<std::string, int>::const_iterator search = groups.find(name_as_string); search != groups.end()) {
+  if (std::map<std::string, int>::const_iterator search = groups.find(name); search != groups.end()) {
     idx = search->second;
     return re2_matchdata_nth_match(idx, self);
   } else {
@@ -754,7 +754,7 @@ static VALUE re2_matchdata_deconstruct_keys(const VALUE self, const VALUE keys) 
       for (i = 0; i < RARRAY_LEN(keys); i++) {
         key = rb_ary_entry(keys, i);
         Check_Type(key, T_SYMBOL);
-        std::string name(rb_id2name(SYM2ID(key)));
+        const char *name = rb_id2name(SYM2ID(key));
 
         if (std::map<std::string, int>::const_iterator search = groups.find(name); search != groups.end()) {
           rb_hash_aset(capturing_groups, key, re2_matchdata_nth_match(search->second, self));

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -129,31 +129,31 @@ static void parse_re2_options(RE2::Options* re2_options, const VALUE options) {
   }
 }
 
-void re2_matchdata_mark(re2_matchdata* self) {
+static void re2_matchdata_mark(re2_matchdata* self) {
   rb_gc_mark(self->regexp);
   rb_gc_mark(self->text);
 }
 
-void re2_matchdata_free(re2_matchdata* self) {
+static void re2_matchdata_free(re2_matchdata* self) {
   if (self->matches) {
     delete[] self->matches;
   }
   free(self);
 }
 
-void re2_scanner_mark(re2_scanner* self) {
+static void re2_scanner_mark(re2_scanner* self) {
   rb_gc_mark(self->regexp);
   rb_gc_mark(self->text);
 }
 
-void re2_scanner_free(re2_scanner* self) {
+static void re2_scanner_free(re2_scanner* self) {
   if (self->input) {
     delete self->input;
   }
   free(self);
 }
 
-void re2_regexp_free(re2_pattern* self) {
+static void re2_regexp_free(re2_pattern* self) {
   if (self->pattern) {
     delete self->pattern;
   }
@@ -180,7 +180,7 @@ static VALUE re2_scanner_allocate(VALUE klass) {
  *   m = RE2::Regexp.new('(\d+)').match("bob 123")
  *   m.string  #=> "bob 123"
  */
-static VALUE re2_matchdata_string(VALUE self) {
+static VALUE re2_matchdata_string(const VALUE self) {
   re2_matchdata *m;
   Data_Get_Struct(self, re2_matchdata, m);
 
@@ -195,7 +195,7 @@ static VALUE re2_matchdata_string(VALUE self) {
  *   c = RE2::Regexp.new('(\d+)').scan("foo")
  *   c.string #=> "foo"
  */
-static VALUE re2_scanner_string(VALUE self) {
+static VALUE re2_scanner_string(const VALUE self) {
   re2_scanner *c;
   Data_Get_Struct(self, re2_scanner, c);
 
@@ -210,7 +210,7 @@ static VALUE re2_scanner_string(VALUE self) {
  *   c = RE2::Regexp.new('(\d+)').scan("foo")
  *   c.eof? #=> true
  */
-static VALUE re2_scanner_eof(VALUE self) {
+static VALUE re2_scanner_eof(const VALUE self) {
   re2_scanner *c;
   Data_Get_Struct(self, re2_scanner, c);
 
@@ -311,7 +311,7 @@ static VALUE re2_scanner_scan(VALUE self) {
 /*
  * Retrieve a matchdata by index or name.
  */
-re2::StringPiece *re2_matchdata_find_match(VALUE idx, VALUE self) {
+static re2::StringPiece *re2_matchdata_find_match(VALUE idx, const VALUE self) {
   int id;
   re2_matchdata *m;
   re2_pattern *p;
@@ -359,7 +359,7 @@ re2::StringPiece *re2_matchdata_find_match(VALUE idx, VALUE self) {
  *   m.size      #=> 2
  *   m.length    #=> 2
  */
-static VALUE re2_matchdata_size(VALUE self) {
+static VALUE re2_matchdata_size(const VALUE self) {
   re2_matchdata *m;
   Data_Get_Struct(self, re2_matchdata, m);
 
@@ -376,7 +376,7 @@ static VALUE re2_matchdata_size(VALUE self) {
  *   m.begin(0)  #=> 1
  *   m.begin(1)  #=> 4
  */
-static VALUE re2_matchdata_begin(VALUE self, VALUE n) {
+static VALUE re2_matchdata_begin(const VALUE self, VALUE n) {
   re2_matchdata *m;
   re2_pattern *p;
   re2::StringPiece *match;
@@ -405,7 +405,7 @@ static VALUE re2_matchdata_begin(VALUE self, VALUE n) {
  *   m.end(0)  #=> 9
  *   m.end(1)  #=> 7
  */
-static VALUE re2_matchdata_end(VALUE self, VALUE n) {
+static VALUE re2_matchdata_end(const VALUE self, VALUE n) {
   re2_matchdata *m;
   re2_pattern *p;
   re2::StringPiece *match;
@@ -433,7 +433,7 @@ static VALUE re2_matchdata_end(VALUE self, VALUE n) {
  *   m = RE2::Regexp.new('(\d+)').match("bob 123")
  *   m.regexp    #=> #<RE2::Regexp /(\d+)/>
  */
-static VALUE re2_matchdata_regexp(VALUE self) {
+static VALUE re2_matchdata_regexp(const VALUE self) {
   re2_matchdata *m;
   Data_Get_Struct(self, re2_matchdata, m);
   return m->regexp;
@@ -447,7 +447,7 @@ static VALUE re2_matchdata_regexp(VALUE self) {
  *   c = RE2::Regexp.new('(\d+)').scan("bob 123")
  *   c.regexp    #=> #<RE2::Regexp /(\d+)/>
  */
-static VALUE re2_scanner_regexp(VALUE self) {
+static VALUE re2_scanner_regexp(const VALUE self) {
   re2_scanner *c;
   Data_Get_Struct(self, re2_scanner, c);
 
@@ -471,7 +471,7 @@ static VALUE re2_regexp_allocate(VALUE klass) {
  *   m = RE2::Regexp.new('(\d+)').match("bob 123")
  *   m.to_a    #=> ["123", "123"]
  */
-static VALUE re2_matchdata_to_a(VALUE self) {
+static VALUE re2_matchdata_to_a(const VALUE self) {
   int i;
   re2_matchdata *m;
   re2_pattern *p;
@@ -496,7 +496,7 @@ static VALUE re2_matchdata_to_a(VALUE self) {
   return array;
 }
 
-static VALUE re2_matchdata_nth_match(int nth, VALUE self) {
+static VALUE re2_matchdata_nth_match(int nth, const VALUE self) {
   re2_matchdata *m;
   re2_pattern *p;
   re2::StringPiece *match;
@@ -518,7 +518,7 @@ static VALUE re2_matchdata_nth_match(int nth, VALUE self) {
   }
 }
 
-static VALUE re2_matchdata_named_match(const char* name, VALUE self) {
+static VALUE re2_matchdata_named_match(const char* name, const VALUE self) {
   int idx;
   re2_matchdata *m;
   re2_pattern *p;
@@ -584,7 +584,7 @@ static VALUE re2_matchdata_named_match(const char* name, VALUE self) {
  *     m["number"] #=> "123"
  *     m[:number]  #=> "123"
  */
-static VALUE re2_matchdata_aref(int argc, VALUE *argv, VALUE self) {
+static VALUE re2_matchdata_aref(int argc, VALUE *argv, const VALUE self) {
   VALUE idx, rest;
   rb_scan_args(argc, argv, "11", &idx, &rest);
 
@@ -604,7 +604,7 @@ static VALUE re2_matchdata_aref(int argc, VALUE *argv, VALUE self) {
  *
  * @return [String] the entire matched string
  */
-static VALUE re2_matchdata_to_s(VALUE self) {
+static VALUE re2_matchdata_to_s(const VALUE self) {
   return re2_matchdata_nth_match(0, self);
 }
 
@@ -620,7 +620,7 @@ static VALUE re2_matchdata_to_s(VALUE self) {
  *   m = RE2::Regexp.new('(\d+)').match("bob 123")
  *   m.inspect    #=> "#<RE2::MatchData \"123\" 1:\"123\">"
  */
-static VALUE re2_matchdata_inspect(VALUE self) {
+static VALUE re2_matchdata_inspect(const VALUE self) {
   int i;
   re2_matchdata *m;
   re2_pattern *p;
@@ -676,7 +676,7 @@ static VALUE re2_matchdata_inspect(VALUE self) {
  *     puts "Unrecognised match"
  *   end
  */
-static VALUE re2_matchdata_deconstruct(VALUE self) {
+static VALUE re2_matchdata_deconstruct(const VALUE self) {
   int i;
   re2_matchdata *m;
   re2_pattern *p;
@@ -729,7 +729,7 @@ static VALUE re2_matchdata_deconstruct(VALUE self) {
  *     puts "Unrecognised match"
  *   end
  */
-static VALUE re2_matchdata_deconstruct_keys(VALUE self, VALUE keys) {
+static VALUE re2_matchdata_deconstruct_keys(const VALUE self, const VALUE keys) {
   int i;
   VALUE capturing_groups, key;
   re2_matchdata *m;
@@ -850,7 +850,7 @@ static VALUE re2_regexp_initialize(int argc, VALUE *argv, VALUE self) {
  *   re2 = RE2::Regexp.new("woo?")
  *   re2.inspect    #=> "#<RE2::Regexp /woo?/>"
  */
-static VALUE re2_regexp_inspect(VALUE self) {
+static VALUE re2_regexp_inspect(const VALUE self) {
   re2_pattern *p;
   VALUE result;
   std::ostringstream output;
@@ -877,7 +877,7 @@ static VALUE re2_regexp_inspect(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?")
  *   re2.to_s    #=> "woo?"
  */
-static VALUE re2_regexp_to_s(VALUE self) {
+static VALUE re2_regexp_to_s(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return ENCODED_STR_NEW(p->pattern->pattern().data(),
@@ -894,7 +894,7 @@ static VALUE re2_regexp_to_s(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?")
  *   re2.ok?    #=> true
  */
-static VALUE re2_regexp_ok(VALUE self) {
+static VALUE re2_regexp_ok(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->ok());
@@ -909,7 +909,7 @@ static VALUE re2_regexp_ok(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :utf8 => true)
  *   re2.utf8?    #=> true
  */
-static VALUE re2_regexp_utf8(VALUE self) {
+static VALUE re2_regexp_utf8(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().encoding() == RE2::Options::EncodingUTF8);
@@ -924,7 +924,7 @@ static VALUE re2_regexp_utf8(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :posix_syntax => true)
  *   re2.posix_syntax?    #=> true
  */
-static VALUE re2_regexp_posix_syntax(VALUE self) {
+static VALUE re2_regexp_posix_syntax(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().posix_syntax());
@@ -939,7 +939,7 @@ static VALUE re2_regexp_posix_syntax(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :longest_match => true)
  *   re2.longest_match?    #=> true
  */
-static VALUE re2_regexp_longest_match(VALUE self) {
+static VALUE re2_regexp_longest_match(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().longest_match());
@@ -954,7 +954,7 @@ static VALUE re2_regexp_longest_match(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :log_errors => true)
  *   re2.log_errors?    #=> true
  */
-static VALUE re2_regexp_log_errors(VALUE self) {
+static VALUE re2_regexp_log_errors(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().log_errors());
@@ -969,7 +969,7 @@ static VALUE re2_regexp_log_errors(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :max_mem => 1024)
  *   re2.max_mem    #=> 1024
  */
-static VALUE re2_regexp_max_mem(VALUE self) {
+static VALUE re2_regexp_max_mem(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return INT2FIX(p->pattern->options().max_mem());
@@ -984,7 +984,7 @@ static VALUE re2_regexp_max_mem(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :literal => true)
  *   re2.literal?    #=> true
  */
-static VALUE re2_regexp_literal(VALUE self) {
+static VALUE re2_regexp_literal(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().literal());
@@ -999,7 +999,7 @@ static VALUE re2_regexp_literal(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :never_nl => true)
  *   re2.never_nl?    #=> true
  */
-static VALUE re2_regexp_never_nl(VALUE self) {
+static VALUE re2_regexp_never_nl(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().never_nl());
@@ -1014,7 +1014,7 @@ static VALUE re2_regexp_never_nl(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :case_sensitive => true)
  *   re2.case_sensitive?    #=> true
  */
-static VALUE re2_regexp_case_sensitive(VALUE self) {
+static VALUE re2_regexp_case_sensitive(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().case_sensitive());
@@ -1030,7 +1030,7 @@ static VALUE re2_regexp_case_sensitive(VALUE self) {
  *   re2.case_insensitive?    #=> false
  *   re2.casefold?    #=> false
  */
-static VALUE re2_regexp_case_insensitive(VALUE self) {
+static VALUE re2_regexp_case_insensitive(const VALUE self) {
   return BOOL2RUBY(re2_regexp_case_sensitive(self) != Qtrue);
 }
 
@@ -1043,7 +1043,7 @@ static VALUE re2_regexp_case_insensitive(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :perl_classes => true)
  *   re2.perl_classes?    #=> true
  */
-static VALUE re2_regexp_perl_classes(VALUE self) {
+static VALUE re2_regexp_perl_classes(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().perl_classes());
@@ -1058,7 +1058,7 @@ static VALUE re2_regexp_perl_classes(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :word_boundary => true)
  *   re2.word_boundary?    #=> true
  */
-static VALUE re2_regexp_word_boundary(VALUE self) {
+static VALUE re2_regexp_word_boundary(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().word_boundary());
@@ -1073,7 +1073,7 @@ static VALUE re2_regexp_word_boundary(VALUE self) {
  *   re2 = RE2::Regexp.new("woo?", :one_line => true)
  *   re2.one_line?    #=> true
  */
-static VALUE re2_regexp_one_line(VALUE self) {
+static VALUE re2_regexp_one_line(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return BOOL2RUBY(p->pattern->options().one_line());
@@ -1085,7 +1085,7 @@ static VALUE re2_regexp_one_line(VALUE self) {
  *
  * @return [String, nil] the error string or nil
  */
-static VALUE re2_regexp_error(VALUE self) {
+static VALUE re2_regexp_error(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   if (p->pattern->ok()) {
@@ -1105,7 +1105,7 @@ static VALUE re2_regexp_error(VALUE self) {
  *
  * @return [String, nil] the offending portion of the regexp or nil
  */
-static VALUE re2_regexp_error_arg(VALUE self) {
+static VALUE re2_regexp_error_arg(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   if (p->pattern->ok()) {
@@ -1124,7 +1124,7 @@ static VALUE re2_regexp_error_arg(VALUE self) {
  *
  * @return [Integer] the regexp "cost"
  */
-static VALUE re2_regexp_program_size(VALUE self) {
+static VALUE re2_regexp_program_size(const VALUE self) {
   re2_pattern *p;
   Data_Get_Struct(self, re2_pattern, p);
   return INT2FIX(p->pattern->ProgramSize());
@@ -1136,7 +1136,7 @@ static VALUE re2_regexp_program_size(VALUE self) {
  *
  * @return [Hash] the options
  */
-static VALUE re2_regexp_options(VALUE self) {
+static VALUE re2_regexp_options(const VALUE self) {
   VALUE options;
   re2_pattern *p;
 
@@ -1189,10 +1189,10 @@ static VALUE re2_regexp_options(VALUE self) {
  *
  * @return [Integer] the number of capturing subpatterns
  */
-static VALUE re2_regexp_number_of_capturing_groups(VALUE self) {
+static VALUE re2_regexp_number_of_capturing_groups(const VALUE self) {
   re2_pattern *p;
-
   Data_Get_Struct(self, re2_pattern, p);
+
   return INT2FIX(p->pattern->NumberOfCapturingGroups());
 }
 
@@ -1205,7 +1205,7 @@ static VALUE re2_regexp_number_of_capturing_groups(VALUE self) {
  *
  * @return [Hash] a hash of names to capturing indices
  */
-static VALUE re2_regexp_named_capturing_groups(VALUE self) {
+static VALUE re2_regexp_named_capturing_groups(const VALUE self) {
   VALUE capturing_groups;
   re2_pattern *p;
 
@@ -1275,7 +1275,7 @@ static VALUE re2_regexp_named_capturing_groups(VALUE self) {
  *     r.match('woo', 1) #=> #<RE2::MatchData "woo" 1:"o">
  *     r.match('woo', 3) #=> #<RE2::MatchData "woo" 1:"o" 2:"o" 3:nil>
  */
-static VALUE re2_regexp_match(int argc, VALUE *argv, VALUE self) {
+static VALUE re2_regexp_match(int argc, VALUE *argv, const VALUE self) {
   int n;
   bool matched;
   re2_pattern *p;
@@ -1308,7 +1308,6 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, VALUE self) {
         static_cast<int>(RSTRING_LEN(text)), RE2::UNANCHORED, 0, 0);
     return BOOL2RUBY(matched);
   } else {
-
     /* Because match returns the whole match as well. */
     n += 1;
 
@@ -1344,7 +1343,7 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, VALUE self) {
  *
  * @return [Boolean] whether the match was successful
  */
-static VALUE re2_regexp_match_p(VALUE self, VALUE text) {
+static VALUE re2_regexp_match_p(const VALUE self, VALUE text) {
   VALUE argv[2];
   argv[0] = text;
   argv[1] = INT2FIX(0);
@@ -1358,7 +1357,7 @@ static VALUE re2_regexp_match_p(VALUE self, VALUE text) {
  * @example
  *   c = RE2::Regexp.new('(\w+)').scan("Foo bar baz")
  */
-static VALUE re2_regexp_scan(VALUE self, VALUE text) {
+static VALUE re2_regexp_scan(const VALUE self, VALUE text) {
   re2_pattern *p;
   re2_scanner *c;
   VALUE scanner;
@@ -1484,7 +1483,7 @@ static VALUE re2_QuoteMeta(VALUE self, VALUE unquoted) {
   return rb_str_new(quoted_string.data(), quoted_string.size());
 }
 
-void re2_set_free(re2_set *self) {
+static void re2_set_free(re2_set *self) {
   if (self->set) {
     delete self->set;
   }
@@ -1674,7 +1673,7 @@ static VALUE re2_set_match_raises_errors_p(VALUE self) {
  *     set.compile
  *     set.match("abcdef", :exception => true)    # => [0, 1]
  */
-static VALUE re2_set_match(int argc, VALUE *argv, VALUE self) {
+static VALUE re2_set_match(int argc, VALUE *argv, const VALUE self) {
   VALUE str, options, exception_option;
   bool raise_exception = true;
   rb_scan_args(argc, argv, "11", &str, &options);

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -6,15 +6,17 @@
  * Released under the BSD Licence, please see LICENSE.txt
  */
 
-#include <ruby.h>
-#include <ruby/encoding.h>
+#include <stdint.h>
+
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include <re2/re2.h>
 #include <re2/set.h>
-#include <stdint.h>
-#include <string>
-#include <sstream>
-#include <vector>
-#include <map>
+#include <ruby.h>
+#include <ruby/encoding.h>
 
 #define BOOL2RUBY(v) (v ? Qtrue : Qfalse)
 #define UNUSED(x) ((void)x)

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -13,11 +13,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
-using std::string;
-using std::ostringstream;
-using std::nothrow;
-using std::map;
-using std::vector;
+#include <map>
 
 #define BOOL2RUBY(v) (v ? Qtrue : Qfalse)
 #define UNUSED(x) ((void)x)
@@ -265,7 +261,7 @@ static VALUE re2_scanner_rewind(VALUE self) {
   re2_scanner *c;
   Data_Get_Struct(self, re2_scanner, c);
 
-  c->input = new(nothrow) re2::StringPiece(StringValuePtr(c->text));
+  c->input = new(std::nothrow) re2::StringPiece(StringValuePtr(c->text));
   c->eof = false;
 
   return self;
@@ -296,9 +292,9 @@ static VALUE re2_scanner_scan(VALUE self) {
   Data_Get_Struct(self, re2_scanner, c);
   Data_Get_Struct(c->regexp, re2_pattern, p);
 
-  vector<RE2::Arg> argv(c->number_of_capturing_groups);
-  vector<RE2::Arg*> args(c->number_of_capturing_groups);
-  vector<string> matches(c->number_of_capturing_groups);
+  std::vector<RE2::Arg> argv(c->number_of_capturing_groups);
+  std::vector<RE2::Arg*> args(c->number_of_capturing_groups);
+  std::vector<std::string> matches(c->number_of_capturing_groups);
 
   if (c->eof) {
     return Qnil;
@@ -348,8 +344,8 @@ re2::StringPiece *re2_matchdata_find_match(VALUE idx, VALUE self) {
   int id;
   re2_matchdata *m;
   re2_pattern *p;
-  map<string, int> groups;
-  string name;
+  std::map<std::string, int> groups;
+  std::string name;
   re2::StringPiece *match;
 
   Data_Get_Struct(self, re2_matchdata, m);
@@ -558,8 +554,8 @@ static VALUE re2_matchdata_named_match(const char* name, VALUE self) {
   int idx;
   re2_matchdata *m;
   re2_pattern *p;
-  map<string, int> groups;
-  string name_as_string(name);
+  std::map<std::string, int> groups;
+  std::string name_as_string(name);
 
   Data_Get_Struct(self, re2_matchdata, m);
   Data_Get_Struct(m->regexp, re2_pattern, p);
@@ -662,7 +658,7 @@ static VALUE re2_matchdata_inspect(VALUE self) {
   re2_matchdata *m;
   re2_pattern *p;
   VALUE match, result;
-  ostringstream output;
+  std::ostringstream output;
 
   Data_Get_Struct(self, re2_matchdata, m);
   Data_Get_Struct(m->regexp, re2_pattern, p);
@@ -771,8 +767,8 @@ static VALUE re2_matchdata_deconstruct_keys(VALUE self, VALUE keys) {
   VALUE capturing_groups, key;
   re2_matchdata *m;
   re2_pattern *p;
-  map<string, int> groups;
-  map<string, int>::iterator iterator;
+  std::map<std::string, int> groups;
+  std::map<std::string, int>::iterator iterator;
 
   Data_Get_Struct(self, re2_matchdata, m);
   Data_Get_Struct(m->regexp, re2_pattern, p);
@@ -793,7 +789,7 @@ static VALUE re2_matchdata_deconstruct_keys(VALUE self, VALUE keys) {
       for (i = 0; i < RARRAY_LEN(keys); i++) {
         key = rb_ary_entry(keys, i);
         Check_Type(key, T_SYMBOL);
-        string name(rb_id2name(SYM2ID(key)));
+        std::string name(rb_id2name(SYM2ID(key)));
 
         if (groups.count(name) == 0) {
           break;
@@ -865,9 +861,9 @@ static VALUE re2_regexp_initialize(int argc, VALUE *argv, VALUE self) {
     RE2::Options re2_options;
     parse_re2_options(re2_options, options);
 
-    p->pattern = new(nothrow) RE2(StringValuePtr(pattern), re2_options);
+    p->pattern = new(std::nothrow) RE2(StringValuePtr(pattern), re2_options);
   } else {
-    p->pattern = new(nothrow) RE2(StringValuePtr(pattern));
+    p->pattern = new(std::nothrow) RE2(StringValuePtr(pattern));
   }
 
   if (p->pattern == 0) {
@@ -892,7 +888,7 @@ static VALUE re2_regexp_initialize(int argc, VALUE *argv, VALUE self) {
 static VALUE re2_regexp_inspect(VALUE self) {
   re2_pattern *p;
   VALUE result;
-  ostringstream output;
+  std::ostringstream output;
 
   Data_Get_Struct(self, re2_pattern, p);
 
@@ -1247,8 +1243,8 @@ static VALUE re2_regexp_number_of_capturing_groups(VALUE self) {
 static VALUE re2_regexp_named_capturing_groups(VALUE self) {
   VALUE capturing_groups;
   re2_pattern *p;
-  map<string, int> groups;
-  map<string, int>::iterator iterator;
+  std::map<std::string, int> groups;
+  std::map<std::string, int>::iterator iterator;
 
   Data_Get_Struct(self, re2_pattern, p);
   groups = p->pattern->NamedCapturingGroups();
@@ -1355,7 +1351,7 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, VALUE self) {
 
     matchdata = rb_class_new_instance(0, 0, re2_cMatchData);
     Data_Get_Struct(matchdata, re2_matchdata, m);
-    m->matches = new(nothrow) re2::StringPiece[n];
+    m->matches = new(std::nothrow) re2::StringPiece[n];
     m->regexp = self;
     m->text = rb_str_dup(text);
     rb_str_freeze(m->text);
@@ -1408,7 +1404,7 @@ static VALUE re2_regexp_scan(VALUE self, VALUE text) {
   scanner = rb_class_new_instance(0, 0, re2_cScanner);
   Data_Get_Struct(scanner, re2_scanner, c);
 
-  c->input = new(nothrow) re2::StringPiece(StringValuePtr(text));
+  c->input = new(std::nothrow) re2::StringPiece(StringValuePtr(text));
   c->regexp = self;
   c->text = text;
 
@@ -1448,7 +1444,7 @@ static VALUE re2_Replace(VALUE self, VALUE str, VALUE pattern,
   /* Take a copy of str so it can be modified in-place by
    * RE2::Replace.
    */
-  string str_as_string(StringValuePtr(str));
+  std::string str_as_string(StringValuePtr(str));
 
   /* Do the replacement. */
   if (rb_obj_is_kind_of(pattern, re2_cRegexp)) {
@@ -1491,7 +1487,7 @@ static VALUE re2_GlobalReplace(VALUE self, VALUE str, VALUE pattern,
    * RE2::GlobalReplace.
    */
   re2_pattern *p;
-  string str_as_string(StringValuePtr(str));
+  std::string str_as_string(StringValuePtr(str));
 
   /* Do the replacement. */
   if (rb_obj_is_kind_of(pattern, re2_cRegexp)) {
@@ -1521,7 +1517,7 @@ static VALUE re2_GlobalReplace(VALUE self, VALUE str, VALUE pattern,
  */
 static VALUE re2_QuoteMeta(VALUE self, VALUE unquoted) {
   UNUSED(self);
-  string quoted_string = RE2::QuoteMeta(StringValuePtr(unquoted));
+  std::string quoted_string = RE2::QuoteMeta(StringValuePtr(unquoted));
   return rb_str_new(quoted_string.data(), quoted_string.size());
 }
 
@@ -1607,7 +1603,7 @@ static VALUE re2_set_initialize(int argc, VALUE *argv, VALUE self) {
     }
   }
 
-  s->set = new(nothrow) RE2::Set(re2_options, re2_anchor);
+  s->set = new(std::nothrow) RE2::Set(re2_options, re2_anchor);
   if (s->set == 0) {
     rb_raise(rb_eNoMemError, "not enough memory to allocate RE2::Set object");
   }


### PR DESCRIPTION
Try to address some of the items from #59 and improve the C++ code of the extension.

Namely:

- Replace use of "using" with explicit naming
- Use references to NamedCapturingGroups, not copies
