### PR TITLE
Prevent overflow if RE2 error strings are too long

### DIFF
--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -1595,7 +1595,7 @@ static VALUE re2_set_add(VALUE self, VALUE pattern) {
   {
     std::string err;
     index = s->set->Add(regex, &err);
-    strncpy(msg, err.c_str(), sizeof(msg));
+    strlcpy(msg, err.c_str(), sizeof(msg));
   }
 
   if (index < 0) {


### PR DESCRIPTION
As strncpy will truncate any error messages over 100 characters long without null termination, switch to using the safer strlcpy which guarantees null termination.
