### PR TITLE
Run compilation tests against Ruby 3.3.0-preview2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.3'
           - '3.2'
           - '3.1'
           - '3.0'
@@ -124,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ["ubuntu-latest", "macos-latest"]
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
         include:
           - ruby: "2.6"
             runs-on: "windows-2019"


### PR DESCRIPTION
Before compiling the native gems against the latest, unreleased version of Ruby, check the gem compiles and passes its tests when the user has to compile against it on install.

See https://github.com/mudge/re2/issues/108
