### PR TITLE
Add workflow to upgrade vendored dependencies

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,26 @@
+name: Upgrade vendored dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 3 1 * *'
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+      - name: Upgrade all vendored dependencies to their latest versions
+        run: ./scripts/update-dependencies
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          branch: 'upgrade-vendored-dependencies'
+          title: 'Upgrade vendored dependencies'
+          commit-message: 'Upgrade vendored dependencies to latest versions'
+          labels: dependencies
+          body: |
+            - Upgrade RE2
+            - Upgrade Abseil

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,9 +1,7 @@
+---
 libre2:
-  version: "2023-09-01"
-  sha256: "5bb6875ae1cd1e9fedde98018c346db7260655f86fdb8837e3075103acd3649b"
-  # sha-256 hash provided in https://github.com/google/re2/releases/download/2023-09-01/re2-2023-09-01.tar.gz
-
+  version: '2023-09-01'
+  sha256: 5bb6875ae1cd1e9fedde98018c346db7260655f86fdb8837e3075103acd3649b
 abseil:
-  version: "20230125.3"
+  version: '20230125.3'
   sha256: 5366d7e7fa7ba0d915014d387b66d0d002c03236448e1ba9ef98122c13b35c36
-  # sha-256 hash provided in https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+require "net/http"
+require "digest/sha2"
+require "yaml"
+
+re2_response = Net::HTTP.get_response(URI("https://github.com/google/re2/releases/latest"))
+exit 1 unless re2_response.is_a?(Net::HTTPRedirection)
+
+re2_release = File.basename(URI(re2_response["Location"]).path)
+re2_redirect = Net::HTTP.get_response(URI("https://github.com/google/re2/releases/download/#{re2_release}/re2-#{re2_release}.tar.gz"))
+exit 1 unless re2_redirect.is_a?(Net::HTTPRedirection)
+
+re2_archive = Net::HTTP.get_response(URI(re2_redirect["Location"]))
+exit 1 unless re2_archive.is_a?(Net::HTTPSuccess)
+re2_sha256sum = Digest::SHA2.hexdigest(re2_archive.body)
+
+abseil_response = Net::HTTP.get_response(URI("https://github.com/abseil/abseil-cpp/releases/latest"))
+exit 1 unless abseil_response.is_a?(Net::HTTPRedirection)
+
+abseil_tag = File.basename(URI(abseil_response["Location"]).path)
+abseil_redirect = Net::HTTP.get_response(URI("https://github.com/abseil/abseil-cpp/archive/refs/tags/#{abseil_tag}.tar.gz"))
+exit 1 unless abseil_redirect.is_a?(Net::HTTPRedirection)
+
+abseil_archive = Net::HTTP.get_response(URI(abseil_redirect["Location"]))
+exit 1 unless abseil_archive.is_a?(Net::HTTPSuccess)
+abseil_sha256sum = Digest::SHA2.hexdigest(abseil_archive.body)
+
+File.write(
+  File.expand_path("../dependencies.yml", __dir__),
+  {
+    "libre2" => { "version" => re2_release, "sha256" => re2_sha256sum },
+    "abseil" => { "version" => abseil_tag, "sha256" => abseil_sha256sum }
+  }.to_yaml
+)


### PR DESCRIPTION
So we can stay on top of updates to both RE2 and Abseil now they are vendored with the gem, run a monthly job to check for any new releases and update `dependencies.yml` accordingly, raising a PR if there are any.

Closes https://github.com/mudge/re2/issues/107
