### PR TITLE
Upgrade mini_portile to v2.8.5

### DIFF
--- a/ext/re2/recipes.rb
+++ b/ext/re2/recipes.rb
@@ -1,5 +1,5 @@
 PACKAGE_ROOT_DIR = File.expand_path('../..', __dir__)
-REQUIRED_MINI_PORTILE_VERSION = '~> 2.8.4' # keep this version in sync with the one in the gemspec
+REQUIRED_MINI_PORTILE_VERSION = '~> 2.8.5' # keep this version in sync with the one in the gemspec
 
 def build_recipe(name, version)
   require 'rubygems'

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rake-compiler", "~> 1.2.1")
   s.add_development_dependency("rake-compiler-dock", "~> 1.3.0")
   s.add_development_dependency("rspec", "~> 3.2")
-  s.add_runtime_dependency("mini_portile2", "~> 2.8.4") # keep version in sync with extconf.rb
+  s.add_runtime_dependency("mini_portile2", "~> 2.8.5") # keep version in sync with extconf.rb
 end


### PR DESCRIPTION
This update builds abseil-cpp in Release mode
(https://github.com/flavorjones/mini_portile/pull/136). For the x86_64 shared object, it appears that this shrinks `re2.so`from 2766744 bytes to 1506992 bytes, a 45% reduction.