### PR TITLE
Modernize usage of Ruby's C extension API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp
 .yardoc
 doc
 Gemfile.lock
+ports/

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -128,6 +128,7 @@ def build_extension(static_p = false)
 
   have_library("stdc++")
   have_header("stdint.h")
+  have_func("rb_gc_mark_movable") # introduced in Ruby 2.7
 
   if !static_p and !have_library("re2")
     abort "You must have re2 installed and specified with --with-re2-dir, please see https://github.com/google/re2/wiki/Install"

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -152,7 +152,13 @@ static void re2_matchdata_free(void * data) {
 }
 
 static size_t re2_matchdata_memsize(const void * data) {
-  return sizeof(re2_matchdata);
+  const re2_matchdata *self = (const re2_matchdata *)data;
+  size_t size = sizeof(re2_matchdata);
+  if (self->matches) {
+    size += sizeof(self->matches);
+  }
+
+  return size;
 }
 
 static const rb_data_type_t re2_matchdata_data_type = {

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -128,7 +128,6 @@ static void parse_re2_options(RE2::Options* re2_options, const VALUE options) {
 #else
 #define rb_gc_mark_movable(x) rb_gc_mark(x)
 #define re2_compact_callback(x)
-#define rb_gc_location(x) x
 #endif
 
 static void re2_matchdata_mark(void *data) {
@@ -137,11 +136,13 @@ static void re2_matchdata_mark(void *data) {
   rb_gc_mark_movable(self->text);
 }
 
+#ifdef HAVE_RB_GC_MARK_MOVABLE
 static void re2_matchdata_update_references(void *data) {
   re2_matchdata *self = (re2_matchdata *)data;
   self->regexp = rb_gc_location(self->regexp);
   self->text = rb_gc_location(self->text);
 }
+#endif
 
 static void re2_matchdata_free(void *data) {
   re2_matchdata *self = (re2_matchdata *)data;
@@ -180,11 +181,13 @@ static void re2_scanner_mark(void *data) {
   rb_gc_mark_movable(self->text);
 }
 
+#ifdef HAVE_RB_GC_MARK_MOVABLE
 static void re2_scanner_update_references(void *data) {
   re2_scanner *self = (re2_scanner *)data;
   self->regexp = rb_gc_location(self->regexp);
   self->text = rb_gc_location(self->text);
 }
+#endif
 
 static void re2_scanner_free(void *data) {
   re2_scanner *self = (re2_scanner *)data;

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -151,7 +151,7 @@ static void re2_matchdata_free(void *data) {
   xfree(self);
 }
 
-static size_t re2_matchdata_memsize(const void * data) {
+static size_t re2_matchdata_memsize(const void *data) {
   const re2_matchdata *self = (const re2_matchdata *)data;
   size_t size = sizeof(re2_matchdata);
   if (self->matches) {

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -131,20 +131,20 @@ static void parse_re2_options(RE2::Options* re2_options, const VALUE options) {
 #define rb_gc_location(x)
 #endif
 
-static void re2_matchdata_mark(void * data) {
-  re2_matchdata* self = (re2_matchdata*)data;
+static void re2_matchdata_mark(void *data) {
+  re2_matchdata *self = (re2_matchdata *)data;
   rb_gc_mark_movable(self->regexp);
   rb_gc_mark_movable(self->text);
 }
 
-static void re2_matchdata_update_references(void * data) {
-  re2_matchdata* self = (re2_matchdata*)data;
+static void re2_matchdata_update_references(void *data) {
+  re2_matchdata *self = (re2_matchdata *)data;
   self->regexp = rb_gc_location(self->regexp);
   self->text = rb_gc_location(self->text);
 }
 
-static void re2_matchdata_free(void * data) {
-  re2_matchdata* self = (re2_matchdata*)data;
+static void re2_matchdata_free(void *data) {
+  re2_matchdata *self = (re2_matchdata *)data;
   if (self->matches) {
     delete[] self->matches;
   }
@@ -175,19 +175,19 @@ static const rb_data_type_t re2_matchdata_data_type = {
 };
 
 static void re2_scanner_mark(void *data) {
-  re2_scanner* self = (re2_scanner *)data;
+  re2_scanner *self = (re2_scanner *)data;
   rb_gc_mark_movable(self->regexp);
   rb_gc_mark_movable(self->text);
 }
 
-static void re2_scanner_update_references(void * data) {
+static void re2_scanner_update_references(void *data) {
   re2_scanner *self = (re2_scanner *)data;
   self->regexp = rb_gc_location(self->regexp);
   self->text = rb_gc_location(self->text);
 }
 
 static void re2_scanner_free(void *data) {
-  re2_scanner* self = (re2_scanner *)data;
+  re2_scanner *self = (re2_scanner *)data;
   if (self->input) {
     delete self->input;
   }
@@ -195,11 +195,12 @@ static void re2_scanner_free(void *data) {
 }
 
 static size_t re2_scanner_memsize(const void *data) {
-  const re2_scanner* self = (const re2_scanner*)data;
+  const re2_scanner *self = (const re2_scanner *)data;
   size_t size = sizeof(re2_scanner);
   if (self->input) {
     size += sizeof(self->input);
   }
+
   return size;
 }
 
@@ -217,7 +218,7 @@ static const rb_data_type_t re2_scanner_data_type = {
 };
 
 static void re2_regexp_free(void *data) {
-  re2_pattern* self = (re2_pattern*)data;
+  re2_pattern *self = (re2_pattern *)data;
   if (self->pattern) {
     delete self->pattern;
   }
@@ -225,12 +226,12 @@ static void re2_regexp_free(void *data) {
 }
 
 static size_t re2_regexp_memsize(const void *data) {
-  const re2_pattern* self = (const re2_pattern*)data;
-
+  const re2_pattern *self = (const re2_pattern *)data;
   size_t size = sizeof(re2_pattern);
   if (self->pattern) {
     size += sizeof(self->pattern);
   }
+
   return size;
 }
 
@@ -441,6 +442,7 @@ static re2::StringPiece *re2_matchdata_find_match(VALUE idx, const VALUE self) {
  */
 static VALUE re2_matchdata_size(const VALUE self) {
   re2_matchdata *m;
+
   TypedData_Get_Struct(self, re2_matchdata, &re2_matchdata_data_type, m);
 
   return INT2FIX(m->number_of_matches);
@@ -1588,6 +1590,7 @@ static size_t re2_set_memsize(const void *data) {
   if (self->set) {
     size += sizeof(self->set);
   }
+
   return size;
 }
 

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -128,7 +128,7 @@ static void parse_re2_options(RE2::Options* re2_options, const VALUE options) {
 #else
 #define rb_gc_mark_movable(x) rb_gc_mark(x)
 #define re2_compact_callback(x)
-#define rb_gc_location(x)
+#define rb_gc_location(x) x
 #endif
 
 static void re2_matchdata_mark(void *data) {

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -181,7 +181,7 @@ static void re2_scanner_mark(void *data) {
 }
 
 static void re2_scanner_update_references(void * data) {
-  re2_matchdata* self = (re2_scanner*)data;
+  re2_scanner *self = (re2_scanner *)data;
   self->regexp = rb_gc_location(self->regexp);
   self->text = rb_gc_location(self->text);
 }

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -148,7 +148,7 @@ static void re2_matchdata_free(void * data) {
   if (self->matches) {
     delete[] self->matches;
   }
-  free(self);
+  xfree(self);
 }
 
 static size_t re2_matchdata_memsize(const void * data) {
@@ -185,7 +185,7 @@ static void re2_scanner_free(void *data) {
   if (self->input) {
     delete self->input;
   }
-  free(self);
+  xfree(self);
 }
 
 static size_t re2_scanner_memsize(const void *data) {
@@ -215,7 +215,7 @@ static void re2_regexp_free(void *data) {
   if (self->pattern) {
     delete self->pattern;
   }
-  free(self);
+  xfree(self);
 }
 
 static size_t re2_regexp_memsize(const void *data) {
@@ -1573,7 +1573,7 @@ static void re2_set_free(void *data) {
   if (self->set) {
     delete self->set;
   }
-  free(self);
+  xfree(self);
 }
 
 static size_t re2_set_memsize(const void *data) {

--- a/spec/re2/match_data_spec.rb
+++ b/spec/re2/match_data_spec.rb
@@ -129,6 +129,12 @@ RSpec.describe RE2::MatchData do
       re = RE2::Regexp.new('(\D+)').match("bob")
       expect(re.string).to be_frozen
     end
+
+    it "does not copy the string if it was already frozen" do
+      string = "bob".freeze
+      re = RE2::Regexp.new('(\D+)').match(string)
+      expect(re.string).to equal(string)
+    end
   end
 
   describe "#size" do


### PR DESCRIPTION
Use the `TypedData` API introduced in Ruby 1.9.2, instead of the old `Data` API that was deprecated in Ruby 2.3.

This allows to implement Write Barriers.

Write barrier protected objects are allowed to be promoted to the old generation, which means they only get marked on major GC, making minor GC faster.

The downside is that the `RB_BJ_WRITE` macro MUST be used to set references, otherwise the referenced object may be garbaged collected.

This also allow to implement GC compaction.
