### PR TITLE
Fix "non-trivial designated initializers not supported" errors

### DIFF
--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -124,7 +124,7 @@ static void parse_re2_options(RE2::Options* re2_options, const VALUE options) {
 
 /* For compatibility with ruby < 2.7 */
 #ifdef HAVE_RB_GC_MARK_MOVABLE
-#define re2_compact_callback(x) .dcompact = (x),
+#define re2_compact_callback(x) (x),
 #else
 #define rb_gc_mark_movable(x) rb_gc_mark(x)
 #define re2_compact_callback(x)
@@ -163,18 +163,18 @@ static size_t re2_matchdata_memsize(const void *ptr) {
 }
 
 static const rb_data_type_t re2_matchdata_data_type = {
-  .wrap_struct_name = "RE2::MatchData",
-  .function = {
-    .dmark = re2_matchdata_mark,
-    .dfree = re2_matchdata_free,
-    .dsize = re2_matchdata_memsize,
+  "RE2::MatchData",
+  {
+    re2_matchdata_mark,
+    re2_matchdata_free,
+    re2_matchdata_memsize,
     re2_compact_callback(re2_matchdata_compact)
   },
-  .parent = NULL,
-  .data = NULL,
+  0,
+  0,
   // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
   // macro to update VALUE references, as to trigger write barriers.
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+  RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 static void re2_scanner_mark(void *ptr) {
@@ -210,18 +210,18 @@ static size_t re2_scanner_memsize(const void *ptr) {
 }
 
 static const rb_data_type_t re2_scanner_data_type = {
-  .wrap_struct_name = "RE2::Scanner",
-  .function = {
-    .dmark = re2_scanner_mark,
-    .dfree = re2_scanner_free,
-    .dsize = re2_scanner_memsize,
+  "RE2::Scanner",
+  {
+    re2_scanner_mark,
+    re2_scanner_free,
+    re2_scanner_memsize,
     re2_compact_callback(re2_scanner_compact)
   },
-  .parent = NULL,
-  .data = NULL,
+  0,
+  0,
   // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
   // macro to update VALUE references, as to trigger write barriers.
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+  RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 static void re2_regexp_free(void *ptr) {
@@ -243,17 +243,17 @@ static size_t re2_regexp_memsize(const void *ptr) {
 }
 
 static const rb_data_type_t re2_regexp_data_type = {
-  .wrap_struct_name = "RE2::Regexp",
-  .function = {
-    .dmark = NULL,
-    .dfree = re2_regexp_free,
-    .dsize = re2_regexp_memsize,
+  "RE2::Regexp",
+  {
+    0,
+    re2_regexp_free,
+    re2_regexp_memsize,
   },
-  .parent = NULL,
-  .data = NULL,
+  0,
+  0,
   // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
   // macro to update VALUE references, as to trigger write barriers.
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+  RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 static VALUE re2_matchdata_allocate(VALUE klass) {
@@ -1604,17 +1604,17 @@ static size_t re2_set_memsize(const void *ptr) {
 }
 
 static const rb_data_type_t re2_set_data_type = {
-  .wrap_struct_name = "RE2::Set",
-  .function = {
-    .dmark = NULL,
-    .dfree = re2_set_free,
-    .dsize = re2_set_memsize,
+  "RE2::Set",
+  {
+    0,
+    re2_set_free,
+    re2_set_memsize,
   },
-  .parent = NULL,
-  .data = NULL,
+  0,
+  0,
   // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
   // macro to update VALUE references, as to trigger write barriers.
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+  RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 static VALUE re2_set_allocate(VALUE klass) {

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -170,6 +170,8 @@ static const rb_data_type_t re2_matchdata_data_type = {
     .dsize = re2_matchdata_memsize,
     re2_compact_callback(re2_matchdata_compact)
   },
+  .parent = NULL,
+  .data = NULL,
   // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
   // macro to update VALUE references, as to trigger write barriers.
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
@@ -215,6 +217,8 @@ static const rb_data_type_t re2_scanner_data_type = {
     .dsize = re2_scanner_memsize,
     re2_compact_callback(re2_scanner_compact)
   },
+  .parent = NULL,
+  .data = NULL,
   // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
   // macro to update VALUE references, as to trigger write barriers.
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
@@ -245,6 +249,8 @@ static const rb_data_type_t re2_regexp_data_type = {
     .dfree = re2_regexp_free,
     .dsize = re2_regexp_memsize,
   },
+  .parent = NULL,
+  .data = NULL,
   // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
   // macro to update VALUE references, as to trigger write barriers.
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
@@ -1604,6 +1610,8 @@ static const rb_data_type_t re2_set_data_type = {
     .dfree = re2_set_free,
     .dsize = re2_set_memsize,
   },
+  .parent = NULL,
+  .data = NULL,
   // IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
   // macro to update VALUE references, as to trigger write barriers.
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED


### PR DESCRIPTION
With g++ v7.3.1 (used with Amazon Linux 2), compiling the extension would fail with these errors:

```
compiling re2.cc
re2.cc:176:1: sorry, unimplemented: non-trivial designated initializers not
supported
 };
 ^
re2.cc:221:1: sorry, unimplemented: non-trivial designated initializers not
supported
 };
 ^
re2.cc:251:1: sorry, unimplemented: non-trivial designated initializers not
supported
 };
 ^
re2.cc:1610:1: sorry, unimplemented: non-trivial designated initializers not
supported
 };
 ^
```

This appears to be happening because the `parent` and `data` fields in `rb_data_type_struct` were omitted.

According to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55606, this issue was fixed in GCC 8.