### PR TITLE
Drop abseil-cpp build workarounds on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,8 @@ jobs:
         with:
           name: cruby-gem
           path: gems
+      - name: Show pkg-config version
+        run: pkg-config --version
       - run: ./scripts/test-gem-install gems
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ If you're using Bundler, you can use the
 [`force_ruby_platform`](https://bundler.io/v2.3/man/gemfile.5.html#FORCE_RUBY_PLATFORM)
 option in your Gemfile.
 
+Windows users attempting to compile [abseil] must use pkgconf 2.1.0 or
+later, or builds will fail with [`undefined reference` errors](https://github.com/pkgconf/pkgconf/issues/322):
+
+    pacman -Sy mingw64/mingw-w64-x86_64-pkgconf
+
+This is not needed when using the precompiled gem or building against a system RE2 library.
+
 Documentation
 -------------
 

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -271,65 +271,6 @@ def build_with_system_libraries
   build_extension
 end
 
-# pkgconf v1.9.3 on Windows incorrectly sorts the output of `pkg-config
-# --libs --static`, resulting in build failures: https://github.com/pkgconf/pkgconf/issues/268.
-# To work around the issue, store the correct order of abseil flags here and add them manually
-# for Windows.
-#
-# Note that `-ldbghelp` is incorrectly added before `-labsl_symbolize` in abseil:
-# https://github.com/abseil/abseil-cpp/issues/1497
-ABSL_LDFLAGS = %w[
-  -labsl_flags
-  -labsl_flags_internal
-  -labsl_flags_marshalling
-  -labsl_flags_reflection
-  -labsl_flags_private_handle_accessor
-  -labsl_flags_commandlineflag
-  -labsl_flags_commandlineflag_internal
-  -labsl_flags_config
-  -labsl_flags_program_name
-  -labsl_cord
-  -labsl_cordz_info
-  -labsl_cord_internal
-  -labsl_cordz_functions
-  -labsl_cordz_handle
-  -labsl_crc_cord_state
-  -labsl_crc32c
-  -labsl_crc_internal
-  -labsl_crc_cpu_detect
-  -labsl_raw_hash_set
-  -labsl_hash
-  -labsl_city
-  -labsl_bad_variant_access
-  -labsl_low_level_hash
-  -labsl_hashtablez_sampler
-  -labsl_exponential_biased
-  -labsl_bad_optional_access
-  -labsl_str_format_internal
-  -labsl_synchronization
-  -labsl_graphcycles_internal
-  -labsl_kernel_timeout_internal
-  -labsl_stacktrace
-  -labsl_symbolize
-  -ldbghelp
-  -labsl_debugging_internal
-  -labsl_demangle_internal
-  -labsl_malloc_internal
-  -labsl_time
-  -labsl_civil_time
-  -labsl_strings
-  -labsl_string_view
-  -labsl_strings_internal
-  -labsl_base
-  -ladvapi32
-  -labsl_spinlock_wait
-  -labsl_int128
-  -labsl_throw_delegate
-  -labsl_raw_logging_internal
-  -labsl_log_severity
-  -labsl_time_zone
-].freeze
-
 def libflag_to_filename(ldflag)
   case ldflag
   when /\A-l(.+)/
@@ -382,14 +323,7 @@ def add_flag(arg, lib_paths)
 end
 
 def add_static_ldflags(flags, lib_paths)
-  static_flags = flags.strip.shellsplit
-
-  if MiniPortile.windows?
-    static_flags.each { |flag| add_flag(flag, lib_paths) unless ABSL_LDFLAGS.include?(flag) }
-    ABSL_LDFLAGS.each { |flag| add_flag(flag, lib_paths) }
-  else
-    static_flags.each { |flag| add_flag(flag, lib_paths) }
-  end
+  flags.strip.shellsplit.each { |flag| add_flag(flag, lib_paths) }
 end
 
 def build_with_vendored_libraries


### PR DESCRIPTION
The linker order problem in  abseil/abseil-cpp#1497 was shipped with abseil-cpp 20230802.0.

pkgconf v2.1.0 fixed pkgconf/pkgconf#268 and pkgconf/pkgconf#322, so we should no longer need to add the abseil linker flags manually.

Update CI to use pkgconf v2.1.0 for Windows machines and a note in README.me about using the right version.
