### PR TITLE
Precompile native gems for Ruby 3.3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
           key: archives-ubuntu-${{hashFiles('ext/re2/extconf.rb')}}
       - run: |
           docker run --rm -v "$(pwd):/re2" -w /re2 \
-            "ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-${{matrix.platform}}" \
+            "ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0.rc1-mri-${{matrix.platform}}" \
             ./scripts/test-gem-build gems ${{matrix.platform}} ${{github.ref_type}}
       - uses: actions/upload-artifact@v3
         with:
@@ -176,7 +176,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -198,7 +198,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -282,7 +282,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -301,7 +301,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -320,7 +320,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{matrix.ruby}}-alpine"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
           key: archives-ubuntu-${{hashFiles('ext/re2/extconf.rb')}}
       - run: |
           docker run --rm -v "$(pwd):/re2" -w /re2 \
-            "ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0.rc1-mri-${{matrix.platform}}" \
+            "ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0.rc2-mri-${{matrix.platform}}" \
             ./scripts/test-gem-build gems ${{matrix.platform}} ${{github.ref_type}}
       - uses: actions/upload-artifact@v3
         with:
@@ -134,6 +134,8 @@ jobs:
             runs-on: "windows-2022"
           - ruby: "3.2"
             runs-on: "windows-2022"
+          - ruby: "head"
+            runs-on: "windows-2022"
     runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@v4
@@ -176,7 +178,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -198,7 +200,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -220,7 +222,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2"]
+        ruby: ["3.1", "3.2", "head"]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -260,7 +262,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -320,7 +322,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3.0-rc1"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{matrix.ruby}}-alpine"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 Older versions are detailed as [GitHub
 releases](https://github.com/mudge/re2/releases) for this project.
 
+## [2.6.0.rc1] - 2023-12-13
+### Added
+- Add precompiled native gem for Ruby 3.3.0-rc1.
+
 ## [2.5.0] - 2023-12-05
 ### Added
 - Add a new matching interface that more closely resembles the underlying RE2
@@ -222,6 +226,7 @@ releases](https://github.com/mudge/re2/releases) for this project.
 ### Fixed
 - In Ruby 1.9.2 and later, re2 will now set the correct encoding for strings
 
+[2.6.0.rc1]: https://github.com/mudge/re2/releases/tag/v2.6.0.rc1
 [2.5.0]: https://github.com/mudge/re2/releases/tag/v2.5.0
 [2.4.3]: https://github.com/mudge/re2/releases/tag/v2.4.3
 [2.4.2]: https://github.com/mudge/re2/releases/tag/v2.4.2

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ Gem::PackageTask.new(RE2_GEM_SPEC) do |p|
   p.need_tar = false
 end
 
-CROSS_RUBY_VERSIONS = %w[3.2.0 3.1.0 3.0.0 2.7.0 2.6.0].join(':')
+CROSS_RUBY_VERSIONS = %w[3.3.0 3.2.0 3.1.0 3.0.0 2.7.0 2.6.0].join(':')
 CROSS_RUBY_PLATFORMS = %w[
   aarch64-linux
   arm-linux

--- a/lib/re2/version.rb
+++ b/lib/re2/version.rb
@@ -10,5 +10,5 @@
 
 
 module RE2
-  VERSION = "2.5.0"
+  VERSION = "2.6.0.rc1"
 end

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
     "spec/re2/scanner_spec.rb"
   ]
   s.add_development_dependency("rake-compiler", "~> 1.2.5")
-  s.add_development_dependency("rake-compiler-dock", "~> 1.4.0.rc1")
+  s.add_development_dependency("rake-compiler-dock", "~> 1.4.0.rc2")
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_runtime_dependency("mini_portile2", "~> 2.8.5") # keep version in sync with extconf.rb
 end

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -38,8 +38,8 @@ Gem::Specification.new do |s|
     "spec/re2/set_spec.rb",
     "spec/re2/scanner_spec.rb"
   ]
-  s.add_development_dependency("rake-compiler", "~> 1.2.1")
-  s.add_development_dependency("rake-compiler-dock", "~> 1.3.0")
+  s.add_development_dependency("rake-compiler", "~> 1.2.5")
+  s.add_development_dependency("rake-compiler-dock", "~> 1.4.0.rc1")
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_runtime_dependency("mini_portile2", "~> 2.8.5") # keep version in sync with extconf.rb
 end


### PR DESCRIPTION
Use [rake-compiler-dock 1.4.0.rc2](https://github.com/rake-compiler/rake-compiler-dock/releases/tag/1.4.0.rc2) to precompile a native gem for Ruby 3.3 and test it on all supported platforms.
