### PR TITLE
Support null bytes in string inputs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+--format documentation

--- a/spec/kernel_spec.rb
+++ b/spec/kernel_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Kernel do
       expect(re).not_to be_case_sensitive
     end
 
+    it "accepts patterns containing null bytes" do
+      re = RE2("a\0b")
+
+      expect(re.pattern).to eq("a\0b")
+    end
+
     it "raises an error if given an inappropriate type" do
       expect { RE2(nil) }.to raise_error(TypeError)
     end

--- a/spec/re2/match_data_spec.rb
+++ b/spec/re2/match_data_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe RE2::MatchData do
   describe "#inspect" do
     it "returns a text representation of the object and indices" do
       md = RE2::Regexp.new('(\d+) (\d+)').match("1234 56")
- 
+
       expect(md.inspect).to eq('#<RE2::MatchData "1234 56" 1:"1234" 2:"56">')
     end
 
@@ -198,6 +198,12 @@ RSpec.describe RE2::MatchData do
       md = RE2::Regexp.new('(\d+) (\d+)?').match("1234 ")
 
       expect(md.inspect).to eq('#<RE2::MatchData "1234 " 1:"1234" 2:nil>')
+    end
+
+    it "supports matches with null bytes" do
+      md = RE2::Regexp.new("(\\w\0\\w) (\\w\0\\w)").match("a\0b c\0d")
+
+      expect(md.inspect).to eq("#<RE2::MatchData \"a\0b c\0d\" 1:\"a\0b\" 2:\"c\0d\">")
     end
   end
 
@@ -239,6 +245,12 @@ RSpec.describe RE2::MatchData do
       expect(md.string[md.begin(:foo)..-1]).to eq('foobar')
     end
 
+    it "returns the offset of the start of a match by something that can be coerced to a String" do
+      md = RE2::Regexp.new('(?P<foo>fo{2})').match('a foobar')
+
+      expect(md.string[md.begin(StringLike.new("foo"))..-1]).to eq('foobar')
+    end
+
     it "returns the offset despite multibyte characters" do
       md = RE2::Regexp.new('(Ruby)').match('I ♥ Ruby')
 
@@ -268,6 +280,12 @@ RSpec.describe RE2::MatchData do
 
       expect(md.begin(:foo)).to be_nil
     end
+
+    it "raises a type error if given an invalid name or number" do
+      md = RE2::Regexp.new('(\d)').match('123')
+
+      expect { md.begin(nil) }.to raise_error(TypeError)
+    end
   end
 
   describe "#end" do
@@ -287,6 +305,12 @@ RSpec.describe RE2::MatchData do
       md = RE2::Regexp.new('(?P<foo>fo{2})').match('a foobar')
 
       expect(md.string[0...md.end(:foo)]).to eq('a foo')
+    end
+
+    it "returns the offset of a match by something that can be coerced to a String" do
+      md = RE2::Regexp.new('(?P<foo>fo{2})').match('a foobar')
+
+      expect(md.string[0...md.end(StringLike.new("foo"))]).to eq('a foo')
     end
 
     it "returns the offset despite multibyte characters" do
@@ -317,6 +341,12 @@ RSpec.describe RE2::MatchData do
       md = RE2::Regexp.new('(\d)').match('123')
 
       expect(md.end(:foo)).to be_nil
+    end
+
+    it "raises a type error if given an invalid name or number" do
+      md = RE2::Regexp.new('(\d)').match('123')
+
+      expect { md.end(nil) }.to raise_error(TypeError)
     end
   end
 

--- a/spec/re2/regexp_spec.rb
+++ b/spec/re2/regexp_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe RE2::Regexp do
       expect(re).to be_a(RE2::Regexp)
     end
 
+    it "accepts patterns containing null bytes" do
+      re = RE2::Regexp.new("a\0b")
+
+      expect(re.pattern).to eq("a\0b")
+    end
+
     it "raises an error if given an inappropriate type" do
       expect { RE2::Regexp.new(nil) }.to raise_error(TypeError)
     end
@@ -39,6 +45,12 @@ RSpec.describe RE2::Regexp do
     it "returns an instance given a pattern and options" do
       re = RE2::Regexp.compile('woo', case_sensitive: false)
       expect(re).to be_a(RE2::Regexp)
+    end
+
+    it "accepts patterns containing null bytes" do
+      re = RE2::Regexp.compile("a\0b")
+
+      expect(re.pattern).to eq("a\0b")
     end
 
     it "raises an error if given an inappropriate type" do
@@ -339,6 +351,12 @@ RSpec.describe RE2::Regexp do
       expect(re.match("My name is Alice Bloggs")).to eq(true)
     end
 
+    it "supports matching against text containing null bytes" do
+      re = RE2::Regexp.new("a\0b")
+
+      expect(re.match("a\0b")).to eq(true)
+    end
+
     it "returns nil if the text does not match the pattern" do
       re = RE2::Regexp.new('My name is (\w+) (\w+)')
 
@@ -511,6 +529,13 @@ RSpec.describe RE2::Regexp do
       expect(md[3]).to eq("three")
     end
 
+    it "supports extracting submatches containing null bytes" do
+      re = RE2::Regexp.new("(a\0b)")
+      md = re.match("a\0bc")
+
+      expect(md[1]).to eq("a\0b")
+    end
+
     it "extracts a specific number of submatches", :aggregate_failures do
       re = RE2::Regexp.new('(\w+) (\w+) (\w+)')
       md = re.match("one two three", submatches: 2)
@@ -599,6 +624,13 @@ RSpec.describe RE2::Regexp do
       expect(re.partial_match?("My age is 99")).to eq(false)
     end
 
+    it "supports matching against text containing null bytes", :aggregate_failures do
+      re = RE2::Regexp.new("a\0b")
+
+      expect(re.partial_match?("a\0b")).to eq(true)
+      expect(re.partial_match?("ab")).to eq(false)
+    end
+
     it "returns false if the pattern is invalid" do
       re = RE2::Regexp.new('???', log_errors: false)
 
@@ -618,6 +650,13 @@ RSpec.describe RE2::Regexp do
 
       expect(re =~ "My name is Alice Bloggs").to eq(true)
       expect(re =~ "My age is 99").to eq(false)
+    end
+
+    it "supports matching against text containing null bytes", :aggregate_failures do
+      re = RE2::Regexp.new("a\0b")
+
+      expect(re =~ "a\0b").to eq(true)
+      expect(re =~ "ab").to eq(false)
     end
 
     it "returns false if the pattern is invalid" do
@@ -660,6 +699,13 @@ RSpec.describe RE2::Regexp do
 
       expect(re.full_match?("My name is Alice Bloggs")).to eq(true)
       expect(re.full_match?("My name is Alice Bloggs and I am 99")).to eq(false)
+    end
+
+    it "supports matching against text containing null bytes", :aggregate_failures do
+      re = RE2::Regexp.new("a\0b")
+
+      expect(re.full_match?("a\0b")).to eq(true)
+      expect(re.full_match?("a\0bc")).to eq(false)
     end
 
     it "returns false if the pattern is invalid" do
@@ -741,6 +787,12 @@ RSpec.describe RE2::Regexp do
       scanner = r.scan("It is a truth universally acknowledged")
 
       expect(scanner).to be_a(RE2::Scanner)
+    end
+
+    it "raises a type error if given invalid input" do
+      r = RE2::Regexp.new('(\w+)')
+
+      expect { r.scan(nil) }.to raise_error(TypeError)
     end
   end
 

--- a/spec/re2/scanner_spec.rb
+++ b/spec/re2/scanner_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe RE2::Scanner do
       expect(scanner.scan).to be_nil
     end
 
+    it "supports scanning inputs with null bytes", :aggregate_failures do
+      r = RE2::Regexp.new("(\\w\0\\w)")
+      scanner = r.scan("a\0b c\0d e\0f")
+
+      expect(scanner.scan).to eq(["a\0b"])
+      expect(scanner.scan).to eq(["c\0d"])
+      expect(scanner.scan).to eq(["e\0f"])
+      expect(scanner.scan).to be_nil
+    end
+
     it "returns UTF-8 matches if the pattern is UTF-8" do
       r = RE2::Regexp.new('(\w+)')
       scanner = r.scan("It")
@@ -188,6 +198,18 @@ RSpec.describe RE2::Scanner do
       scanner.rewind
 
       expect(scanner.to_enum.first).to eq(["1"])
+    end
+
+    it "supports inputs with null bytes", :aggregate_failures do
+      r = RE2::Regexp.new("(\\w\0\\w)")
+      scanner = r.scan("a\0b c\0d")
+
+      expect(scanner.to_enum.first).to eq(["a\0b"])
+      expect(scanner.to_enum.first).to eq(["c\0d"])
+
+      scanner.rewind
+
+      expect(scanner.to_enum.first).to eq(["a\0b"])
     end
 
     it "resets the eof? check", :aggregate_failures do

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -123,6 +123,14 @@ RSpec.describe RE2::Set do
       expect(set.match("def", exception: false)).to be_empty
     end
 
+    it "supports matching null bytes", :aggregate_failures do
+      set = RE2::Set.new
+      set.add("a\0b")
+      set.compile
+
+      expect(set.match("a\0b", exception: false)).to eq([0])
+    end
+
     it "returns an empty array if there is no match when :exception is true" do
       skip "Underlying RE2::Set::Match does not output error information" unless RE2::Set.match_raises_errors?
 

--- a/spec/re2_spec.rb
+++ b/spec/re2_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe RE2 do
       expect(RE2.Replace("woo", "o", "a")).to eq("wao")
     end
 
+    it "supports inputs with null bytes" do
+      expect(RE2.Replace("w\0oo", "o", "a")).to eq("w\0ao")
+    end
+
+    it "supports patterns with null bytes" do
+      expect(RE2.Replace("w\0oo", "\0", "o")).to eq("wooo")
+    end
+
+    it "supports replacements with null bytes" do
+      expect(RE2.Replace("woo", "o", "\0")).to eq("w\0o")
+    end
+
     it "performs replacement based on regular expressions" do
       expect(RE2.Replace("woo", "o+", "e")).to eq("we")
     end
@@ -80,6 +92,18 @@ RSpec.describe RE2 do
   describe ".GlobalReplace" do
     it "replaces every occurrence of a pattern" do
       expect(RE2.GlobalReplace("woo", "o", "a")).to eq("waa")
+    end
+
+    it "supports inputs with null bytes" do
+      expect(RE2.GlobalReplace("w\0oo", "o", "a")).to eq("w\0aa")
+    end
+
+    it "supports patterns with null bytes" do
+      expect(RE2.GlobalReplace("w\0\0oo", "\0", "a")).to eq("waaoo")
+    end
+
+    it "supports replacements with null bytes" do
+      expect(RE2.GlobalReplace("woo", "o", "\0")).to eq("w\0\0")
     end
 
     it "performs replacement based on regular expressions" do
@@ -166,6 +190,10 @@ RSpec.describe RE2 do
 
     it "supports passing something that can be coerced to a String as input" do
       expect(RE2.QuoteMeta(StringLike.new("1.5"))).to eq('1\.5')
+    end
+
+    it "supports strings containing null bytes" do
+      expect(RE2.QuoteMeta("abc\0def")).to eq('abc\x00def')
     end
   end
 end


### PR DESCRIPTION
GitHub: https://github.com/mudge/re2/issues/130

Ensure that whenever we pass Ruby string data into RE2 we use the data's explicit length as returned by RSTRING_LEN rather than relying on null-termination. RSTRING_PTR doesn't guarantee this (see https://docs.ruby-lang.org/en/3.3/extension_rdoc.html#label-VALUE+type+conversion) and we can end up either truncating input or, worse, over-reading.
