### PR TITLE
Don’t populate LIBPATH

### DIFF
--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -226,8 +226,6 @@ module RE2
         .shellsplit
         .map { |flag| flag.delete_prefix('-L') }
 
-      $LIBPATH = static_library_paths | $LIBPATH
-
       # Replace all -l flags that can be found in one of the static library
       # paths with the absolute path instead.
       minimal_pkg_config(pc_file, '--libs-only-l', '--static')


### PR DESCRIPTION
Given we only want to use absolute, static paths for libraries, remove another potential way for vendored libraries to be linked dynamically by excluding their lib directories from the LIBPATH.