### PR TITLE
Split CI jobs by OS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         platform:
           - "aarch64-linux"
           - "arm-linux"
-          - "arm64-darwin" # github actions does not support this runtime as of 2022-12, but let's build anyway
+          - "arm64-darwin"
           - "x64-mingw-ucrt"
           - "x64-mingw32"
           - "x86-linux"
@@ -370,6 +370,24 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-darwin-gem
+          path: gems
+      - run: ./scripts/test-gem-install gems
+
+  test-precompiled-arm64-darwin:
+    needs: ["build-precompiled-gems"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-arm64-darwin-gem
           path: gems
       - run: ./scripts/test-gem-install gems
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,8 +56,8 @@ jobs:
           key: archives-ubuntu-${{hashFiles('ext/re2/extconf.rb')}}
       - run: |
           docker run --rm -v "$(pwd):/re2" -w /re2 \
-            "ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-${{matrix.platform}}" \
-            ./scripts/test-gem-build gems ${{matrix.platform}} ${{github.ref_type}}
+            "ghcr.io/rake-compiler/rake-compiler-dock-image:1.5.0-mri-${{matrix.platform}}" \
+            ./scripts/test-gem-build gems ${{matrix.platform}}
       - uses: actions/upload-artifact@v4
         with:
           name: "cruby-${{matrix.platform}}-gem"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
           name: "cruby-${{matrix.platform}}-gem"
           path: gems
 
-  compile-and-test-system-re2-versions:
+  test-re2-abi:
     needs: ["build-cruby-gem"]
     runs-on: ubuntu-20.04
     strategy:
@@ -112,59 +112,61 @@ jobs:
           path: gems
       - run: ./scripts/test-gem-install gems --enable-system-libraries
 
-  compile-and-test-vendored-dependencies:
+  test-linux-vendored:
     needs: ["build-cruby-gem"]
     strategy:
       fail-fast: false
       matrix:
-        runs-on: ["ubuntu-latest", "macos-latest"]
         ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
         sys: ["enable", "disable"]
-        include:
-          - ruby: "2.6"
-            runs-on: "windows-2019"
-            sys: "enable"
-          - ruby: "2.6"
-            runs-on: "windows-2019"
-            sys: "disable"
-          - ruby: "2.7"
-            runs-on: "windows-2019"
-            sys: "enable"
-          - ruby: "2.7"
-            runs-on: "windows-2019"
-            sys: "disable"
-          - ruby: "3.0"
-            runs-on: "windows-2019"
-            sys: "enable"
-          - ruby: "3.0"
-            runs-on: "windows-2019"
-            sys: "disable"
-          - ruby: "3.1"
-            runs-on: "windows-2022"
-            sys: "enable"
-          - ruby: "3.1"
-            runs-on: "windows-2022"
-            sys: "disable"
-          - ruby: "3.2"
-            runs-on: "windows-2022"
-            sys: "enable"
-          - ruby: "3.2"
-            runs-on: "windows-2022"
-            sys: "disable"
-          - ruby: "3.3"
-            runs-on: "windows-2022"
-            sys: "enable"
-          - ruby: "3.3"
-            runs-on: "windows-2022"
-            sys: "disable"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           apt-get: libre2-dev
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-gem
+          path: gems
+      - run: ./scripts/test-gem-install gems --${{ matrix.sys }}-system-libraries
+        shell: bash
+
+  test-macos-vendored:
+    needs: ["build-cruby-gem"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        sys: ["enable", "disable"]
+    runs-on: "macos-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
           brew: re2
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-gem
+          path: gems
+      - run: ./scripts/test-gem-install gems --${{ matrix.sys }}-system-libraries
+        shell: bash
+
+  test-windows-2019-vendored:
+    needs: ["build-cruby-gem"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0"]
+        sys: ["enable", "disable"]
+    runs-on: "windows-2019"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
           mingw: re2
       - uses: actions/download-artifact@v4
         with:
@@ -173,27 +175,28 @@ jobs:
       - run: ./scripts/test-gem-install gems --${{ matrix.sys }}-system-libraries
         shell: bash
 
-  compile-and-test-vendored-dependencies-with-system-install:
+  test-windows-2022-vendored:
     needs: ["build-cruby-gem"]
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1", "3.2", "3.3"]
+        sys: ["enable", "disable"]
+    runs-on: "windows-2022"
     steps:
       - uses: actions/checkout@v4
-      - name: Install RE2
-        run: sudo apt-get install -y libre2-dev
-      - uses: ruby/setup-ruby@v1
-        id: setup-ruby
+      - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.3"
-          bundler-cache: true
+          ruby-version: ${{ matrix.ruby }}
+          mingw: re2
       - uses: actions/download-artifact@v4
         with:
           name: cruby-gem
           path: gems
-      - name: "Link libre2 into Ruby's lib directory"
-        run: ln -s /usr/lib/x86_64-linux-gnu/libre2.so ${{ steps.setup-ruby.outputs.ruby-prefix }}/lib/libre2.so
-      - run: ./scripts/test-gem-install gems
+      - run: ./scripts/test-gem-install gems --${{ matrix.sys }}-system-libraries
+        shell: bash
 
-  compile-and-test-on-freebsd:
+  test-freebsd-vendored:
     needs: ["build-cruby-gem"]
     strategy:
       fail-fast: false
@@ -212,6 +215,26 @@ jobs:
           copyback: false
           prepare: pkg install -y ruby devel/ruby-gems sysutils/rubygem-bundler devel/pkgconf devel/cmake shells/bash devel/re2
           run: ./scripts/test-gem-install gems --${{ matrix.sys }}-system-libraries
+
+  test-vendored-and-system:
+    needs: ["build-cruby-gem"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install RE2
+        run: sudo apt-get install -y libre2-dev
+      - uses: ruby/setup-ruby@v1
+        id: setup-ruby
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-gem
+          path: gems
+      - name: "Link libre2 into Ruby's lib directory"
+        run: ln -s /usr/lib/x86_64-linux-gnu/libre2.so ${{ steps.setup-ruby.outputs.ruby-prefix }}/lib/libre2.so
+      - run: ./scripts/test-gem-install gems
 
   test-precompiled-aarch64-linux:
     needs: ["build-precompiled-gems"]


### PR DESCRIPTION
To make the matrix for the "compile-and-test-vendored-dependencies" job a bit easier to manage, split it into separate jobs by OS.
