### PR TITLE
Use explicit versions of macOS in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
       matrix:
         ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
         sys: ["enable", "disable"]
-    runs-on: "macos-latest"
+    runs-on: "macos-13"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby-pkgs@v1
@@ -356,7 +356,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
See https://github.com/flavorjones/ruby-c-extensions-explained/pull/30/commits/db36156105a9d8c30478f56de72ad44c9494736a
