### PR TITLE
Run ruby_memcheck in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -452,3 +452,20 @@ jobs:
           path: pkg
       - run: apk add bash libstdc++ gcompat
       - run: ./scripts/test-gem-install
+
+  ruby-memcheck:
+    runs-on: "ubuntu-latest"
+    env:
+      BUNDLE_WITH: memcheck
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ports/archives
+          key: archives-ubuntu-${{ hashFiles('ext/re2/extconf.rb') }}
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "3.3"
+          apt-get: valgrind
+          bundler-cache: true
+      - run: bundle exec rake spec:valgrind

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "> 12.3.2"
+
+group :memcheck, optional: true do
+  gem "ruby_memcheck"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -46,6 +46,17 @@ end
 
 RSpec::Core::RakeTask.new(:spec)
 
+begin
+  require 'ruby_memcheck'
+  require 'ruby_memcheck/rspec/rake_task'
+
+  namespace :spec do
+    RubyMemcheck::RSpec::RakeTask.new(valgrind: :compile)
+  end
+rescue LoadError
+  # Only define the spec:valgrind task if ruby_memcheck is installed
+end
+
 namespace :gem do
   cross_platforms.each do |platform|
 


### PR DESCRIPTION
So we can catch any new memory leaks, run ruby_memcheck as part of the build.
