### PR TITLE
Test against Ruby 3.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         sys: ["enable", "disable"]
     runs-on: "ubuntu-latest"
     steps:
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         sys: ["enable", "disable"]
     runs-on: "macos-13"
     steps:


### PR DESCRIPTION
Now Ruby 3.4.0-preview1 is available, add it to the build matrix for Ubuntu and macOS (prerelease versions are not generally available for Windows).