### PR TITLE
Upgrade to rake-compiler-dock 1.5.1

### DIFF
--- a/re2.gemspec
+++ b/re2.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     "spec/re2/scanner_spec.rb"
   ]
   s.add_development_dependency("rake-compiler", "~> 1.2.7")
-  s.add_development_dependency("rake-compiler-dock", "~> 1.5.0")
+  s.add_development_dependency("rake-compiler-dock", "~> 1.5.1")
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_runtime_dependency("mini_portile2", "~> 2.8.7") # keep version in sync with extconf.rb
 end


### PR DESCRIPTION
Since RE2 2024-06-01, the CI build for x86-linux and x86_64-linux slowed from around 15 minutes to almost an hour. This turned out to be due to the rake-compiler-dock images for those platforms having pkg-config 0.27.1 which performs very slowly with RE2's .pc file compared to more recent versions. This will instead use pkg-config 0.29.2 which should take a fraction of a second compared to the minutes 0.27.1 took to execute commands such as `pkg-config --libs-only-L --static re2.pc`.

Thanks to @flavorjones for putting out a fix so promptly.
