### PR TITLE
Split out separate GNU and Musl gems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,25 +35,45 @@ jobs:
           name: cruby-gem
           path: pkg/*.gem
 
-  precompile-aarch64-linux:
+  precompile-aarch64-linux-gnu:
     uses: ./.github/workflows/precompile-gem.yml
     with:
-      platform: aarch64-linux
+      platform: aarch64-linux-gnu
 
-  precompile-arm-linux:
+  precompile-aarch64-linux-musl:
     uses: ./.github/workflows/precompile-gem.yml
     with:
-      platform: arm-linux
+      platform: aarch64-linux-musl
 
-  precompile-x86-linux:
+  precompile-arm-linux-gnu:
     uses: ./.github/workflows/precompile-gem.yml
     with:
-      platform: x86-linux
+      platform: arm-linux-gnu
 
-  precompile-x86_64-linux:
+  precompile-arm-linux-musl:
     uses: ./.github/workflows/precompile-gem.yml
     with:
-      platform: x86_64-linux
+      platform: arm-linux-musl
+
+  precompile-x86-linux-gnu:
+    uses: ./.github/workflows/precompile-gem.yml
+    with:
+      platform: x86-linux-gnu
+
+  precompile-x86-linux-musl:
+    uses: ./.github/workflows/precompile-gem.yml
+    with:
+      platform: x86-linux-musl
+
+  precompile-x86_64-linux-gnu:
+    uses: ./.github/workflows/precompile-gem.yml
+    with:
+      platform: x86_64-linux-gnu
+
+  precompile-x86_64-linux-musl:
+    uses: ./.github/workflows/precompile-gem.yml
+    with:
+      platform: x86_64-linux-musl
 
   precompile-arm64-darwin:
     uses: ./.github/workflows/precompile-gem.yml
@@ -85,7 +105,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ruby: ["3.4.0-rc1", "2.6"] # oldest and newest
+        ruby: ["3.4.0-rc1", "3.0"] # oldest and newest
         libre2:
           - version: "20150501"
             soname: 0
@@ -128,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
         sys: ["enable", "disable"]
     runs-on: "ubuntu-latest"
     steps:
@@ -151,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
         sys: ["enable", "disable"]
     runs-on: "macos-13"
     steps:
@@ -174,14 +194,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0"]
         sys: ["enable", "disable"]
     runs-on: "windows-2019"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: "3.0"
           mingw: re2
           bundler-cache: true
       - uses: actions/download-artifact@v4
@@ -259,39 +278,60 @@ jobs:
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
-  test-precompiled-aarch64-linux:
-    needs: "precompile-aarch64-linux"
+  test-precompiled-aarch64-linux-gnu:
+    needs: "precompile-aarch64-linux-gnu"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: cruby-aarch64-linux-gem
+          name: cruby-aarch64-linux-gnu-gem
           path: pkg
       - name: Enable execution of multi-architecture containers by QEMU
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - run: |
           docker run --rm -v "$(pwd):/re2" -w /re2 \
-            --platform=linux/arm64/v8 \
+            --platform=linux/arm64 \
             ruby:${{ matrix.ruby }} \
             ./scripts/test-gem-install
 
-  test-precompiled-arm-linux:
-    needs: "precompile-arm-linux"
+  test-precompiled-aarch64-linux-musl:
+    needs: "precompile-aarch64-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: cruby-arm-linux-gem
+          name: cruby-aarch64-linux-musl-gem
+          path: pkg
+      - name: Enable execution of multi-architecture containers by QEMU
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - run: |
+          docker run --rm -v "$(pwd):/re2" -w /re2 \
+            --platform=linux/arm64 \
+            ruby:${{ matrix.ruby }}-alpine \
+            sh -c "gem update --system && apk add bash && ./scripts/test-gem-install"
+
+  test-precompiled-arm-linux-gnu:
+    needs: "precompile-arm-linux-gnu"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-arm-linux-gnu-gem
           path: pkg
       - name: enable execution of multi-architecture containers by qemu
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -301,18 +341,39 @@ jobs:
             ruby:${{ matrix.ruby }} \
             ./scripts/test-gem-install
 
-  test-precompiled-x86-linux:
-    needs: "precompile-x86-linux"
+  test-precompiled-arm-linux-musl:
+    needs: "precompile-arm-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: cruby-x86-linux-gem
+          name: cruby-arm-linux-musl-gem
+          path: pkg
+      - name: enable execution of multi-architecture containers by qemu
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - run: |
+          docker run --rm -v "$(pwd):/re2" -w /re2 \
+            --platform=linux/arm/v7 \
+            ruby:${{ matrix.ruby }}-alpine \
+            sh -c "gem update --system && apk add bash && ./scripts/test-gem-install"
+
+  test-precompiled-x86-linux-gnu:
+    needs: "precompile-x86-linux-gnu"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-x86-linux-gnu-gem
           path: pkg
       - name: Enable execution of multi-architecture containers by QEMU
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -322,12 +383,33 @@ jobs:
             ruby:${{ matrix.ruby }} \
             ./scripts/test-gem-install
 
-  test-precompiled-x86_64-linux:
-    needs: "precompile-x86_64-linux"
+  test-precompiled-x86-linux-musl:
+    needs: "precompile-x86-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-x86-linux-musl-gem
+          path: pkg
+      - name: Enable execution of multi-architecture containers by QEMU
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - run: |
+          docker run --rm -v "$(pwd):/re2" -w /re2 \
+            --platform=linux/386 \
+            ruby:${{ matrix.ruby }}-alpine \
+            sh -c "gem update --system && apk add bash && ./scripts/test-gem-install"
+
+  test-precompiled-x86_64-linux-gnu:
+    needs: "precompile-x86_64-linux-gnu"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -337,18 +419,37 @@ jobs:
           bundler-cache: true
       - uses: actions/download-artifact@v4
         with:
-          name: cruby-x86_64-linux-gem
+          name: cruby-x86_64-linux-gnu-gem
           path: pkg
       - run: ./scripts/test-gem-install
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
+
+  test-precompiled-x86_64-linux-musl:
+    needs: "precompile-x86_64-linux-musl"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+    runs-on: ubuntu-latest
+    container:
+      image: "ruby:${{ matrix.ruby }}-alpine"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-x86_64-linux-musl-gem
+          path: pkg
+      - run: gem update --system
+      - run: apk add bash
+      - run: ./scripts/test-gem-install
 
   test-precompiled-arm64-darwin:
     needs: "precompile-arm64-darwin"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -369,7 +470,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
@@ -409,16 +510,12 @@ jobs:
 
   test-precompiled-x64-mingw32:
     needs: "precompile-x64-mingw32"
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["2.6", "2.7", "3.0"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "${{ matrix.ruby }}"
+          ruby-version: "3.0"
           bundler-cache: true
       - uses: actions/download-artifact@v4
         with:
@@ -428,24 +525,6 @@ jobs:
         shell: bash
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
-
-  test-precompiled-x86_64-alpine:
-    needs: "precompile-x86_64-linux"
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
-    runs-on: ubuntu-latest
-    container:
-      image: "ruby:${{ matrix.ruby }}-alpine"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: cruby-x86_64-linux-gem
-          path: pkg
-      - run: apk add bash libstdc++ gcompat
-      - run: ./scripts/test-gem-install
 
   ruby-memcheck:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,22 +90,12 @@ jobs:
     with:
       platform: x64-mingw-ucrt
 
-  precompile-x64-mingw32:
-    uses: ./.github/workflows/precompile-gem.yml
-    with:
-      platform: x64-mingw32
-
-  precompile-x86-mingw32:
-    uses: ./.github/workflows/precompile-gem.yml
-    with:
-      platform: x86-mingw32
-
   test-re2-abi:
     needs: "build-cruby-gem"
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ruby: ["3.4.0-rc1", "3.0"] # oldest and newest
+        ruby: ["3.4.0-rc1", "3.1"] # oldest and newest
         libre2:
           - version: "20150501"
             soname: 0
@@ -148,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
         sys: ["enable", "disable"]
     runs-on: "ubuntu-latest"
     steps:
@@ -171,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
         sys: ["enable", "disable"]
     runs-on: "macos-13"
     steps:
@@ -186,29 +176,6 @@ jobs:
           name: cruby-gem
           path: pkg
       - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
-        env:
-          BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
-
-  test-windows-2019:
-    needs: "build-cruby-gem"
-    strategy:
-      fail-fast: false
-      matrix:
-        sys: ["enable", "disable"]
-    runs-on: "windows-2019"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby-pkgs@v1
-        with:
-          ruby-version: "3.0"
-          mingw: re2
-          bundler-cache: true
-      - uses: actions/download-artifact@v4
-        with:
-          name: cruby-gem
-          path: pkg
-      - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
-        shell: bash
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -283,7 +250,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -304,7 +271,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -325,7 +292,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -346,7 +313,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -367,7 +334,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -388,7 +355,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -409,7 +376,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -430,7 +397,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{ matrix.ruby }}-alpine"
@@ -449,7 +416,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -470,7 +437,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
@@ -502,24 +469,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: cruby-x64-mingw-ucrt-gem
-          path: pkg
-      - run: ./scripts/test-gem-install
-        shell: bash
-        env:
-          BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
-
-  test-precompiled-x64-mingw32:
-    needs: "precompile-x64-mingw32"
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.0"
-          bundler-cache: true
-      - uses: actions/download-artifact@v4
-        with:
-          name: cruby-x64-mingw32-gem
           path: pkg
       - run: ./scripts/test-gem-install
         shell: bash

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ RE2(non_latin1_pattern.encode("ISO-8859-1"), utf8: false).match(non_latin1_text.
 
 This gem requires the following to run:
 
-* [Ruby](https://www.ruby-lang.org/en/) 3.0 to 3.4.0-rc1
+* [Ruby](https://www.ruby-lang.org/en/) 3.1 to 3.4.0-rc1
 
 It supports the following RE2 ABI versions:
 
@@ -271,7 +271,7 @@ Where possible, a pre-compiled native gem will be provided for the following pla
     * `aarch64-linux`, `arm-linux`, `x86-linux` and `x86_64-linux` (requires [glibc](https://www.gnu.org/software/libc/) 2.29+, RubyGems 3.3.22+ and Bundler 2.3.21+)
     * [musl](https://musl.libc.org/)-based systems such as [Alpine](https://alpinelinux.org) are supported with Bundler 2.5.6+
 * macOS `x86_64-darwin` and `arm64-darwin`
-* Windows `x64-mingw32` and `x64-mingw-ucrt`
+* Windows `x64-mingw-ucrt`
 
 ### Verifying the gems
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ RE2(non_latin1_pattern.encode("ISO-8859-1"), utf8: false).match(non_latin1_text.
 
 This gem requires the following to run:
 
-* [Ruby](https://www.ruby-lang.org/en/) 2.6 to 3.3
+* [Ruby](https://www.ruby-lang.org/en/) 3.0 to 3.4.0-rc1
 
 It supports the following RE2 ABI versions:
 
@@ -268,8 +268,8 @@ It supports the following RE2 ABI versions:
 Where possible, a pre-compiled native gem will be provided for the following platforms:
 
 * Linux
-    * `aarch64-linux`, `arm-linux`, `x86-linux` and `x86_64-linux` (requires [glibc](https://www.gnu.org/software/libc/) 2.29+)
-    * [musl](https://musl.libc.org/)-based systems such as [Alpine](https://alpinelinux.org) are supported as long as a [glibc-compatible library is installed](https://wiki.alpinelinux.org/wiki/Running_glibc_programs)
+    * `aarch64-linux`, `arm-linux`, `x86-linux` and `x86_64-linux` (requires [glibc](https://www.gnu.org/software/libc/) 2.29+, RubyGems 3.3.22+ and Bundler 2.3.21+)
+    * [musl](https://musl.libc.org/)-based systems such as [Alpine](https://alpinelinux.org) are supported with Bundler 2.5.6+
 * macOS `x86_64-darwin` and `arm64-darwin`
 * Windows `x64-mingw32` and `x64-mingw-ucrt`
 

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ cross_platforms = %w[
   x86_64-linux-musl
 ].freeze
 
-ENV['RUBY_CC_VERSION'] = %w[3.4.0 3.3.5 3.2.0 3.1.0 3.0.0].join(':')
+ENV['RUBY_CC_VERSION'] = %w[3.4.0 3.3.5 3.2.0 3.1.0].join(':')
 
 Gem::PackageTask.new(re2_gemspec).define
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,18 +18,22 @@ re2_gemspec.files << abseil_archive
 re2_gemspec.files << re2_archive
 
 cross_platforms = %w[
-  aarch64-linux
-  arm-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
   arm64-darwin
   x64-mingw-ucrt
   x64-mingw32
-  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
   x86-mingw32
   x86_64-darwin
-  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 ].freeze
 
-ENV['RUBY_CC_VERSION'] = %w[3.4.0 3.3.5 3.2.0 3.1.0 3.0.0 2.7.0 2.6.0].join(':')
+ENV['RUBY_CC_VERSION'] = %w[3.4.0 3.3.5 3.2.0 3.1.0 3.0.0].join(':')
 
 Gem::PackageTask.new(re2_gemspec).define
 


### PR DESCRIPTION
Due to changes in rake-compiler-dock, running a single Linux gem for both GNU and Musl libraries no longer works reliably so precompile separate gems and drop support for older Rubies accordingly.
