### PR TITLE
Restore Ruby 2.6, 2.7, and 3.0 support

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4.0-rc1"
+          ruby-version: "3.4"
       - name: Upgrade all vendored dependencies to their latest versions
         run: ./scripts/update-dependencies
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4.0-rc1"
+          ruby-version: "3.4"
       - run: gem install --no-document yard redcarpet
       - run: yardoc
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/precompile-gem.yml
+++ b/.github/workflows/precompile-gem.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4.0-rc1"
+          ruby-version: "3.4"
           bundler-cache: true
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           key: archives-ubuntu-${{ hashFiles('dependencies.yml') }}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4.0-rc1"
+          ruby-version: "3.4"
           bundler-cache: true
       - run: bundle exec rake gem
       - uses: actions/upload-artifact@v4
@@ -90,12 +90,22 @@ jobs:
     with:
       platform: x64-mingw-ucrt
 
+  precompile-x64-mingw32:
+    uses: ./.github/workflows/precompile-gem.yml
+    with:
+      platform: x64-mingw32
+
+  precompile-x86-mingw32:
+    uses: ./.github/workflows/precompile-gem.yml
+    with:
+      platform: x86-mingw32
+
   test-re2-abi:
     needs: "build-cruby-gem"
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ruby: ["3.4.0-rc1", "3.1"] # oldest and newest
+        ruby: ["3.4", "2.6"] # oldest and newest
         libre2:
           - version: "20150501"
             soname: 0
@@ -129,7 +139,7 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install --enable-system-libraries
+      - run: ./scripts/test-gem-install default --enable-system-libraries
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -138,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         sys: ["enable", "disable"]
     runs-on: "ubuntu-latest"
     steps:
@@ -152,7 +162,7 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
+      - run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -161,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         sys: ["enable", "disable"]
     runs-on: "macos-13"
     steps:
@@ -175,7 +185,31 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
+      - run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
+        env:
+          BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
+
+  test-windows-2019:
+    needs: "build-cruby-gem"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0"]
+        sys: ["enable", "disable"]
+    runs-on: "windows-2019"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
+          mingw: re2
+          bundler-cache: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-gem
+          path: pkg
+      - run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
+        shell: bash
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -184,7 +218,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "head"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
         sys: ["enable", "disable"]
     runs-on: "windows-2022"
     steps:
@@ -198,7 +232,7 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
+      - run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
         shell: bash
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
@@ -221,7 +255,7 @@ jobs:
           usesh: true
           copyback: false
           prepare: pkg install -y ruby devel/ruby-gems sysutils/rubygem-bundler devel/pkgconf devel/cmake shells/bash devel/re2
-          run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
+          run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
 
   test-vendored-and-system:
     needs: "build-cruby-gem"
@@ -233,7 +267,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         id: setup-ruby
         with:
-          ruby-version: "3.4.0-rc1"
+          ruby-version: "3.4"
           bundler-cache: true
       - uses: actions/download-artifact@v4
         with:
@@ -241,7 +275,7 @@ jobs:
           path: pkg
       - name: "Link libre2 into Ruby's lib directory"
         run: ln -s /usr/lib/x86_64-linux-gnu/libre2.so ${{ steps.setup-ruby.outputs.ruby-prefix }}/lib/libre2.so
-      - run: ./scripts/test-gem-install
+      - run: ./scripts/test-gem-install default
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -250,7 +284,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -264,14 +306,22 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm64 \
             ruby:${{ matrix.ruby }} \
-            ./scripts/test-gem-install
+            ./scripts/test-gem-install ${{ matrix.rubygems }}
 
   test-precompiled-aarch64-linux-musl:
     needs: "precompile-aarch64-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -285,14 +335,22 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm64 \
             ruby:${{ matrix.ruby }}-alpine \
-            ./scripts/test-gem-install
+            ./scripts/test-gem-install ${{ matrix.rubygems }}
 
   test-precompiled-arm-linux-gnu:
     needs: "precompile-arm-linux-gnu"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -306,14 +364,22 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm/v7 \
             ruby:${{ matrix.ruby }} \
-            ./scripts/test-gem-install
+            ./scripts/test-gem-install ${{ matrix.rubygems }}
 
   test-precompiled-arm-linux-musl:
     needs: "precompile-arm-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -327,14 +393,22 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm/v7 \
             ruby:${{ matrix.ruby }}-alpine \
-            ./scripts/test-gem-install
+            ./scripts/test-gem-install ${{ matrix.rubygems }}
 
   test-precompiled-x86-linux-gnu:
     needs: "precompile-x86-linux-gnu"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -348,14 +422,22 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/386 \
             ruby:${{ matrix.ruby }} \
-            ./scripts/test-gem-install
+            ./scripts/test-gem-install ${{ matrix.rubygems }}
 
   test-precompiled-x86-linux-musl:
     needs: "precompile-x86-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -369,26 +451,35 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/386 \
             ruby:${{ matrix.ruby }}-alpine \
-            ./scripts/test-gem-install
+            ./scripts/test-gem-install ${{ matrix.rubygems }}
 
   test-precompiled-x86_64-linux-gnu:
     needs: "precompile-x86_64-linux-gnu"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby }}"
+          rubygems: "${{ matrix.rubygems }}"
           bundler-cache: true
       - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-linux-gnu-gem
           path: pkg
-      - run: ./scripts/test-gem-install
+      - run: ./scripts/test-gem-install default
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -397,7 +488,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{ matrix.ruby }}-alpine"
@@ -407,26 +506,35 @@ jobs:
         with:
           name: cruby-x86_64-linux-musl-gem
           path: pkg
-      - run: ./scripts/test-gem-install
+      - run: ./scripts/test-gem-install ${{ matrix.rubygems }}
 
   test-precompiled-arm64-darwin:
     needs: "precompile-arm64-darwin"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby }}"
+          rubygems: "${{ matrix.rubygems }}"
           bundler-cache: true
       - uses: actions/download-artifact@v4
         with:
           name: cruby-arm64-darwin-gem
           path: pkg
-      - run: ./scripts/test-gem-install
+      - run: ./scripts/test-gem-install default
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -435,19 +543,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4.0-rc1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+          - { ruby: "3.1", rubygems: "default" }
+          - { ruby: "3.2", rubygems: "default" }
+          - { ruby: "3.3", rubygems: "default" }
+          - { ruby: "3.4", rubygems: "default" }
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby }}"
+          rubygems: "${{ matrix.rubygems }}"
           bundler-cache: true
       - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-darwin-gem
           path: pkg
-      - run: ./scripts/test-gem-install
+      - run: ./scripts/test-gem-install default
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -456,7 +573,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "head"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -468,7 +585,34 @@ jobs:
         with:
           name: cruby-x64-mingw-ucrt-gem
           path: pkg
-      - run: ./scripts/test-gem-install
+      - run: ./scripts/test-gem-install default
+        shell: bash
+        env:
+          BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
+
+  test-precompiled-x64-mingw32:
+    needs: "precompile-x64-mingw32"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0"]
+        include:
+          - { ruby: "2.6", rubygems: "3.4.22" }
+          - { ruby: "2.7", rubygems: "3.4.22" }
+          - { ruby: "3.0", rubygems: "3.5.23" }
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
+          rubygems: "${{ matrix.rubygems }}"
+          bundler-cache: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-x64-mingw32-gem
+          path: pkg
+      - run: ./scripts/test-gem-install default
         shell: bash
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
@@ -485,7 +629,7 @@ jobs:
           key: archives-ubuntu-${{ hashFiles('dependencies.yml') }}
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.4.0-rc1"
+          ruby-version: "3.4"
           apt-get: valgrind
           bundler-cache: true
       - run: bundle exec rake spec:valgrind

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ RE2(non_latin1_pattern.encode("ISO-8859-1"), utf8: false).match(non_latin1_text.
 
 This gem requires the following to run:
 
-* [Ruby](https://www.ruby-lang.org/en/) 3.1 to 3.4.0-rc1
+* [Ruby](https://www.ruby-lang.org/en/) 2.6 to 3.4
 
 It supports the following RE2 ABI versions:
 
@@ -271,7 +271,7 @@ Where possible, a pre-compiled native gem will be provided for the following pla
     * `aarch64-linux`, `arm-linux`, `x86-linux` and `x86_64-linux` (requires [glibc](https://www.gnu.org/software/libc/) 2.29+, RubyGems 3.3.22+ and Bundler 2.3.21+)
     * [musl](https://musl.libc.org/)-based systems such as [Alpine](https://alpinelinux.org) are supported with Bundler 2.5.6+
 * macOS `x86_64-darwin` and `arm64-darwin`
-* Windows `x64-mingw-ucrt`
+* Windows `x64-mingw32` and `x64-mingw-ucrt`
 
 ### Verifying the gems
 

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ cross_platforms = %w[
   x86_64-linux-musl
 ].freeze
 
-ENV['RUBY_CC_VERSION'] = %w[3.4.0 3.3.5 3.2.0 3.1.0].join(':')
+ENV['RUBY_CC_VERSION'] = '3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10'
 
 Gem::PackageTask.new(re2_gemspec).define
 

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/mudge/re2"
   s.extensions = ["ext/re2/extconf.rb"]
   s.license = "BSD-3-Clause"
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 2.6.0"
   s.files = [
     "dependencies.yml",
     "ext/re2/extconf.rb",
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     "spec/re2/scanner_spec.rb"
   ]
   s.add_development_dependency("rake-compiler", "~> 1.2.7")
-  s.add_development_dependency("rake-compiler-dock", "~> 1.7.0.rc1")
+  s.add_development_dependency("rake-compiler-dock", "~> 1.8.0")
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_runtime_dependency("mini_portile2", "~> 2.8.7") # keep version in sync with extconf.rb
 end

--- a/scripts/test-gem-install
+++ b/scripts/test-gem-install
@@ -2,6 +2,14 @@
 
 set -eu
 
+rubygems=${1:-default}
+shift
+
+if [ "$rubygems" != "default" ]
+then
+  gem update --system "$rubygems"
+fi
+
 gem install --no-document pkg/*.gem -- "$@"
 cd "$(dirname "$(gem which re2)")/.."
 bundle


### PR DESCRIPTION
- **Restore Ruby 3.0 support**
- **Upgrade to rake-compiler-dock 1.7.0**
