### PR TITLE
Set RUBY_CC_VERSION using RakeCompilerDock.set_ruby_cc_version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -335,7 +335,7 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm64 \
             ruby:${{ matrix.ruby }}-alpine \
-            ./scripts/test-gem-install ${{ matrix.rubygems }}
+            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install ${{ matrix.rubygems }}"
 
   test-precompiled-arm-linux-gnu:
     needs: "precompile-arm-linux-gnu"
@@ -393,7 +393,7 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm/v7 \
             ruby:${{ matrix.ruby }}-alpine \
-            ./scripts/test-gem-install ${{ matrix.rubygems }}
+            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install ${{ matrix.rubygems }}"
 
   test-precompiled-x86-linux-gnu:
     needs: "precompile-x86-linux-gnu"
@@ -451,7 +451,7 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/386 \
             ruby:${{ matrix.ruby }}-alpine \
-            ./scripts/test-gem-install ${{ matrix.rubygems }}
+            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install ${{ matrix.rubygems }}"
 
   test-precompiled-x86_64-linux-gnu:
     needs: "precompile-x86_64-linux-gnu"
@@ -506,6 +506,7 @@ jobs:
         with:
           name: cruby-x86_64-linux-musl-gem
           path: pkg
+      - run: apk update && apk add libstdc++
       - run: ./scripts/test-gem-install ${{ matrix.rubygems }}
 
   test-precompiled-arm64-darwin:

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ cross_platforms = %w[
   x86_64-linux-musl
 ].freeze
 
-ENV['RUBY_CC_VERSION'] = '3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10'
+ENV['RUBY_CC_VERSION'] = RakeCompilerDock.ruby_cc_version("3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6")
 
 Gem::PackageTask.new(re2_gemspec).define
 

--- a/Rakefile
+++ b/Rakefile
@@ -70,6 +70,7 @@ namespace :gem do
     desc "Compile and build native gem for #{platform} platform"
     task platform do
       RakeCompilerDock.sh <<~SCRIPT, platform: platform, verbose: true
+        rbenv shell 3.1.6 &&
         gem install bundler --no-document &&
         bundle &&
         bundle exec rake native:#{platform} pkg/#{re2_gemspec.full_name}-#{Gem::Platform.new(platform)}.gem PATH="/usr/local/bin:$PATH"

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ cross_platforms = %w[
   x86_64-linux-musl
 ].freeze
 
-ENV['RUBY_CC_VERSION'] = RakeCompilerDock.ruby_cc_version("3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6")
+RakeCompilerDock.set_ruby_cc_version("~> 2.6", "~> 3.0")
 
 Gem::PackageTask.new(re2_gemspec).define
 

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     "spec/re2/scanner_spec.rb"
   ]
   s.add_development_dependency("rake-compiler", "~> 1.2.7")
-  s.add_development_dependency("rake-compiler-dock", "~> 1.8.0")
+  s.add_development_dependency("rake-compiler-dock", "~> 1.9.1")
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_runtime_dependency("mini_portile2", "~> 2.8.7") # keep version in sync with extconf.rb
 end


### PR DESCRIPTION
This avoids the need to hard-code specific patch-level versions.

See https://github.com/rake-compiler/rake-compiler-dock/releases/tag/v1.9.1.