### PR TITLE
Test against Ruby 3.5 preview versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "3.5"]
         sys: ["enable", "disable"]
     runs-on: "ubuntu-latest"
     steps:
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "3.5"]
         sys: ["enable", "disable"]
     runs-on: "macos-13"
     steps:
@@ -194,13 +194,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ruby: ["3.4", "head"]
         sys: ["enable", "disable"]
     runs-on: "windows-2022"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ${{ matrix.ruby }}
           mingw: re2
           bundler-cache: true
       - uses: actions/download-artifact@v4
@@ -217,13 +218,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ruby: ["3.4", "head"]
         sys: ["enable", "disable"]
     runs-on: "windows-2025"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ${{ matrix.ruby }}
           mingw: re2
           bundler-cache: true
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
As Ruby 3.5.0-preview1 was released back in April (see https://www.ruby-lang.org/en/news/2025/04/18/ruby-3-5-0-preview1-released/), add it to the build (note prerelease versions of Ruby are not made available for Windows so we use Ruby HEAD instead).
