### PR TITLE
Drop support for Ruby versions older than 3.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,22 +90,12 @@ jobs:
     with:
       platform: x64-mingw-ucrt
 
-  precompile-x64-mingw32:
-    uses: ./.github/workflows/precompile-gem.yml
-    with:
-      platform: x64-mingw32
-
-  precompile-x86-mingw32:
-    uses: ./.github/workflows/precompile-gem.yml
-    with:
-      platform: x86-mingw32
-
   test-re2-abi:
     needs: "build-cruby-gem"
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ruby: ["3.4", "2.6"] # oldest and newest
+        ruby: ["3.4", "3.1"] # oldest and newest
         libre2:
           - version: "20150501"
             soname: 0
@@ -139,7 +129,7 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install default --enable-system-libraries
+      - run: ./scripts/test-gem-install --enable-system-libraries
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -148,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "3.5"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "3.5"]
         sys: ["enable", "disable"]
     runs-on: "ubuntu-latest"
     steps:
@@ -162,7 +152,7 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
+      - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -171,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "3.5"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "3.5"]
         sys: ["enable", "disable"]
     runs-on: "macos-14"
     steps:
@@ -185,7 +175,7 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
+      - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -208,7 +198,7 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
+      - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
         shell: bash
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
@@ -232,7 +222,7 @@ jobs:
         with:
           name: cruby-gem
           path: pkg
-      - run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
+      - run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
         shell: bash
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
@@ -255,7 +245,7 @@ jobs:
           usesh: true
           copyback: false
           prepare: pkg install -y ruby devel/ruby-gems sysutils/rubygem-bundler devel/pkgconf devel/cmake shells/bash devel/re2
-          run: ./scripts/test-gem-install default --${{ matrix.sys }}-system-libraries
+          run: ./scripts/test-gem-install --${{ matrix.sys }}-system-libraries
 
   test-vendored-and-system:
     needs: "build-cruby-gem"
@@ -275,7 +265,7 @@ jobs:
           path: pkg
       - name: "Link libre2 into Ruby's lib directory"
         run: ln -s /usr/lib/x86_64-linux-gnu/libre2.so ${{ steps.setup-ruby.outputs.ruby-prefix }}/lib/libre2.so
-      - run: ./scripts/test-gem-install default
+      - run: ./scripts/test-gem-install
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -284,15 +274,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -306,22 +288,14 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm64 \
             ruby:${{ matrix.ruby }} \
-            ./scripts/test-gem-install ${{ matrix.rubygems }}
+            ./scripts/test-gem-install
 
   test-precompiled-aarch64-linux-musl:
     needs: "precompile-aarch64-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -335,22 +309,14 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm64 \
             ruby:${{ matrix.ruby }}-alpine \
-            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install ${{ matrix.rubygems }}"
+            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install"
 
   test-precompiled-arm-linux-gnu:
     needs: "precompile-arm-linux-gnu"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -364,22 +330,14 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm/v7 \
             ruby:${{ matrix.ruby }} \
-            ./scripts/test-gem-install ${{ matrix.rubygems }}
+            ./scripts/test-gem-install
 
   test-precompiled-arm-linux-musl:
     needs: "precompile-arm-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -393,22 +351,14 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm/v7 \
             ruby:${{ matrix.ruby }}-alpine \
-            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install ${{ matrix.rubygems }}"
+            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install"
 
   test-precompiled-x86-linux-gnu:
     needs: "precompile-x86-linux-gnu"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -422,22 +372,14 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/386 \
             ruby:${{ matrix.ruby }} \
-            ./scripts/test-gem-install ${{ matrix.rubygems }}
+            ./scripts/test-gem-install
 
   test-precompiled-x86-linux-musl:
     needs: "precompile-x86-linux-musl"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -451,35 +393,26 @@ jobs:
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/386 \
             ruby:${{ matrix.ruby }}-alpine \
-            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install ${{ matrix.rubygems }}"
+            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install"
 
   test-precompiled-x86_64-linux-gnu:
     needs: "precompile-x86_64-linux-gnu"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby }}"
-          rubygems: "${{ matrix.rubygems }}"
           bundler-cache: true
       - uses: actions/download-artifact@v5
         with:
           name: cruby-x86_64-linux-gnu-gem
           path: pkg
-      - run: ./scripts/test-gem-install default
+      - run: ./scripts/test-gem-install
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -488,15 +421,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{ matrix.ruby }}-alpine"
@@ -507,35 +432,26 @@ jobs:
           name: cruby-x86_64-linux-musl-gem
           path: pkg
       - run: apk update && apk add libstdc++
-      - run: ./scripts/test-gem-install ${{ matrix.rubygems }}
+      - run: ./scripts/test-gem-install
 
   test-precompiled-arm64-darwin:
     needs: "precompile-arm64-darwin"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: "macos-14"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby }}"
-          rubygems: "${{ matrix.rubygems }}"
           bundler-cache: true
       - uses: actions/download-artifact@v5
         with:
           name: cruby-arm64-darwin-gem
           path: pkg
-      - run: ./scripts/test-gem-install default
+      - run: ./scripts/test-gem-install
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -544,28 +460,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
-        include:
-          - { ruby: "2.6", rubygems: "3.4.22" }
-          - { ruby: "2.7", rubygems: "3.4.22" }
-          - { ruby: "3.0", rubygems: "3.5.23" }
-          - { ruby: "3.1", rubygems: "default" }
-          - { ruby: "3.2", rubygems: "default" }
-          - { ruby: "3.3", rubygems: "default" }
-          - { ruby: "3.4", rubygems: "default" }
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
     runs-on: "macos-15-intel"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby }}"
-          rubygems: "${{ matrix.rubygems }}"
           bundler-cache: true
       - uses: actions/download-artifact@v5
         with:
           name: cruby-x86_64-darwin-gem
           path: pkg
-      - run: ./scripts/test-gem-install default
+      - run: ./scripts/test-gem-install
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
 
@@ -586,7 +493,7 @@ jobs:
         with:
           name: cruby-x64-mingw-ucrt-gem
           path: pkg
-      - run: ./scripts/test-gem-install default
+      - run: ./scripts/test-gem-install
         shell: bash
         env:
           BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,16 +55,6 @@ jobs:
     with:
       platform: arm-linux-musl
 
-  precompile-x86-linux-gnu:
-    uses: ./.github/workflows/precompile-gem.yml
-    with:
-      platform: x86-linux-gnu
-
-  precompile-x86-linux-musl:
-    uses: ./.github/workflows/precompile-gem.yml
-    with:
-      platform: x86-linux-musl
-
   precompile-x86_64-linux-gnu:
     uses: ./.github/workflows/precompile-gem.yml
     with:
@@ -350,48 +340,6 @@ jobs:
       - run: |
           docker run --rm -v "$(pwd):/re2" -w /re2 \
             --platform=linux/arm/v7 \
-            ruby:${{ matrix.ruby }}-alpine \
-            /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install"
-
-  test-precompiled-x86-linux-gnu:
-    needs: "precompile-x86-linux-gnu"
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v5
-        with:
-          name: cruby-x86-linux-gnu-gem
-          path: pkg
-      - name: Enable execution of multi-architecture containers by QEMU
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - run: |
-          docker run --rm -v "$(pwd):/re2" -w /re2 \
-            --platform=linux/386 \
-            ruby:${{ matrix.ruby }} \
-            ./scripts/test-gem-install
-
-  test-precompiled-x86-linux-musl:
-    needs: "precompile-x86-linux-musl"
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v5
-        with:
-          name: cruby-x86-linux-musl-gem
-          path: pkg
-      - name: Enable execution of multi-architecture containers by QEMU
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - run: |
-          docker run --rm -v "$(pwd):/re2" -w /re2 \
-            --platform=linux/386 \
             ruby:${{ matrix.ruby }}-alpine \
             /bin/sh -c "apk update && apk add libstdc++ && ./scripts/test-gem-install"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ releases](https://github.com/mudge/re2/releases) for this project.
   no longer supported.
 - Remove support and native gems for Ruby 2.6, 2.7, and 3.0 (as it accounts
   for less than 1% of downloads in the past 60 days).
+- Remove native gems for 32-bit platforms, specifically x86-linux-gnu,
+  x86-linux-musl, and x86-mingw32
 
 ### Changed
 - Upgrade the bundled version of Abseil to 20250814.1. Note this now requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ releases](https://github.com/mudge/re2/releases) for this project.
 ### Removed
 - Compilation on macOS now targets macOS 10.14 so older versions of macOS are
   no longer supported.
+- Remove support and native gems for Ruby 2.6, 2.7, and 3.0 (as it accounts
+  for less than 1% of downloads in the past 60 days).
 
 ### Changed
 - Upgrade the bundled version of Abseil to 20250814.1. Note this now requires

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ RE2(non_latin1_pattern.encode("ISO-8859-1"), utf8: false).match(non_latin1_text.
 
 This gem requires the following to run:
 
-* [Ruby](https://www.ruby-lang.org/en/) 2.6 to 3.4
+* [Ruby](https://www.ruby-lang.org/en/) 3.1 to 3.4
 
 It supports the following RE2 ABI versions:
 

--- a/README.md
+++ b/README.md
@@ -271,10 +271,10 @@ It supports the following RE2 ABI versions:
 Where possible, a pre-compiled native gem will be provided for the following platforms:
 
 * Linux
-    * `aarch64-linux`, `arm-linux`, `x86-linux` and `x86_64-linux` (requires [glibc](https://www.gnu.org/software/libc/) 2.29+, RubyGems 3.3.22+ and Bundler 2.3.21+)
+    * `aarch64-linux`, `arm-linux`, and `x86_64-linux` (requires [glibc](https://www.gnu.org/software/libc/) 2.29+, RubyGems 3.3.22+ and Bundler 2.3.21+)
     * [musl](https://musl.libc.org/)-based systems such as [Alpine](https://alpinelinux.org) are supported with Bundler 2.5.6+
 * macOS 10.14+ `x86_64-darwin` and `arm64-darwin`
-* Windows 2022+ `x64-mingw32` and `x64-mingw-ucrt`
+* Windows 2022+ `x64-mingw-ucrt`
 
 ### Verifying the gems
 

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ cross_platforms = %w[
   x86_64-linux-musl
 ].freeze
 
-RakeCompilerDock.set_ruby_cc_version("~> 2.6", "~> 3.0")
+RakeCompilerDock.set_ruby_cc_version("~> 3.1")
 
 Gem::PackageTask.new(re2_gemspec).define
 

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -140,7 +140,6 @@ module RE2
 
       have_library("stdc++")
       have_header("stdint.h")
-      have_func("rb_gc_mark_movable") # introduced in Ruby 2.7
 
       minimal_program = <<~SRC
         #include <re2/re2.h>

--- a/ext/re2/extconf.rb
+++ b/ext/re2/extconf.rb
@@ -131,10 +131,8 @@ module RE2
     end
 
     def build_extension
-      # Enable optional warnings but disable deprecated register warning for Ruby 2.6 support
       $CFLAGS << " -Wall -Wextra -funroll-loops"
       $CXXFLAGS << " -Wall -Wextra -funroll-loops"
-      $CPPFLAGS << " -Wno-register"
 
       # Pass -x c++ to force gcc to compile the test program
       # as C++ (as it will end in .c by default).
@@ -154,13 +152,9 @@ module RE2
       end
 
       if re2_requires_version_flag
-        # Recent versions of re2 depend directly on abseil, which requires a
-        # compiler with C++14 support (see
-        # https://github.com/abseil/abseil-cpp/issues/1127 and
-        # https://github.com/abseil/abseil-cpp/issues/1431). However, the
-        # `std=c++14` flag doesn't appear to suffice; we need at least
-        # `std=c++17`.
-        abort "Cannot compile re2 with your compiler: recent versions require C++17 support." unless %w[c++23 c++20 c++17 c++11 c++0x].any? do |std|
+        # Recent versions of RE2 depend directly on Abseil, which requires a
+        # compiler with C++17 support.
+        abort "Cannot compile re2 with your compiler: recent versions require C++17 support." unless %w[c++20 c++17 c++11 c++0x].any? do |std|
           checking_for("re2 that compiles with #{std} standard") do
             if try_compile(minimal_program, compile_options + " -std=#{std}")
               compile_options << " -std=#{std}"

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -125,27 +125,17 @@ static void parse_re2_options(RE2::Options* re2_options, const VALUE options) {
   }
 }
 
-/* For compatibility with Ruby < 2.7 */
-#ifdef HAVE_RB_GC_MARK_MOVABLE
-#define re2_compact_callback(x) (x),
-#else
-#define rb_gc_mark_movable(x) rb_gc_mark(x)
-#define re2_compact_callback(x)
-#endif
-
 static void re2_matchdata_mark(void *ptr) {
   re2_matchdata *m = reinterpret_cast<re2_matchdata *>(ptr);
   rb_gc_mark_movable(m->regexp);
   rb_gc_mark_movable(m->text);
 }
 
-#ifdef HAVE_RB_GC_MARK_MOVABLE
 static void re2_matchdata_compact(void *ptr) {
   re2_matchdata *m = reinterpret_cast<re2_matchdata *>(ptr);
   m->regexp = rb_gc_location(m->regexp);
   m->text = rb_gc_location(m->text);
 }
-#endif
 
 static void re2_matchdata_free(void *ptr) {
   re2_matchdata *m = reinterpret_cast<re2_matchdata *>(ptr);
@@ -171,7 +161,7 @@ static const rb_data_type_t re2_matchdata_data_type = {
     re2_matchdata_mark,
     re2_matchdata_free,
     re2_matchdata_memsize,
-    re2_compact_callback(re2_matchdata_compact)
+    re2_matchdata_compact
   },
   0,
   0,
@@ -186,13 +176,11 @@ static void re2_scanner_mark(void *ptr) {
   rb_gc_mark_movable(s->text);
 }
 
-#ifdef HAVE_RB_GC_MARK_MOVABLE
 static void re2_scanner_compact(void *ptr) {
   re2_scanner *s = reinterpret_cast<re2_scanner *>(ptr);
   s->regexp = rb_gc_location(s->regexp);
   s->text = rb_gc_location(s->text);
 }
-#endif
 
 static void re2_scanner_free(void *ptr) {
   re2_scanner *s = reinterpret_cast<re2_scanner *>(ptr);
@@ -218,7 +206,7 @@ static const rb_data_type_t re2_scanner_data_type = {
     re2_scanner_mark,
     re2_scanner_free,
     re2_scanner_memsize,
-    re2_compact_callback(re2_scanner_compact)
+    re2_scanner_compact
   },
   0,
   0,

--- a/re2.gemspec
+++ b/re2.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/mudge/re2"
   s.extensions = ["ext/re2/extconf.rb"]
   s.license = "BSD-3-Clause"
-  s.required_ruby_version = ">= 2.6.0"
+  s.required_ruby_version = ">= 3.1.0"
   s.files = [
     "dependencies.yml",
     "ext/re2/extconf.rb",

--- a/scripts/test-gem-install
+++ b/scripts/test-gem-install
@@ -2,14 +2,6 @@
 
 set -eu
 
-rubygems=${1:-default}
-shift
-
-if [ "$rubygems" != "default" ]
-then
-  gem update --system "$rubygems"
-fi
-
 gem install --no-document pkg/*.gem -- "$@"
 cd "$(dirname "$(gem which re2)")/.."
 bundle


### PR DESCRIPTION
Based on the logs from rubygems.org in the past 60 days, Ruby versions older than 3.1 account for less than 0.2% of downloads. See https://ui.honeycomb.io/ruby-together/datasets/rubygems.org/result/ms4mhTPGhaJ?vs=hideCompare&cstype_0=tsbar&tab=overview

I've long kept support for old versions even if they were considered end-of-life but only under the assumption people were still actively using those versions in production. Given the rubygems.org stats and similar version support from the likes of much more popular projects such as Nokogiri, let's finally drop support and simplify maintenance.
