### PR TITLE
Release GVL during matching

### DIFF
--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -253,7 +253,7 @@ static void parse_re2_options(RE2::Options* re2_options, const VALUE options) {
 }
 
 static void re2_matchdata_mark(void *ptr) {
-  re2_matchdata *m = reinterpret_cast<re2_matchdata *>(ptr);
+  re2_matchdata *m = static_cast<re2_matchdata *>(ptr);
   rb_gc_mark_movable(m->regexp);
 
   /* Text must not be movable because StringPiece matches hold pointers into
@@ -263,12 +263,12 @@ static void re2_matchdata_mark(void *ptr) {
 }
 
 static void re2_matchdata_compact(void *ptr) {
-  re2_matchdata *m = reinterpret_cast<re2_matchdata *>(ptr);
+  re2_matchdata *m = static_cast<re2_matchdata *>(ptr);
   m->regexp = rb_gc_location(m->regexp);
 }
 
 static void re2_matchdata_free(void *ptr) {
-  re2_matchdata *m = reinterpret_cast<re2_matchdata *>(ptr);
+  re2_matchdata *m = static_cast<re2_matchdata *>(ptr);
   if (m->matches) {
     delete[] m->matches;
   }
@@ -276,7 +276,7 @@ static void re2_matchdata_free(void *ptr) {
 }
 
 static size_t re2_matchdata_memsize(const void *ptr) {
-  const re2_matchdata *m = reinterpret_cast<const re2_matchdata *>(ptr);
+  const re2_matchdata *m = static_cast<const re2_matchdata *>(ptr);
   size_t size = sizeof(*m);
   if (m->matches) {
     size += sizeof(*m->matches) * m->number_of_matches;
@@ -301,7 +301,7 @@ static const rb_data_type_t re2_matchdata_data_type = {
 };
 
 static void re2_scanner_mark(void *ptr) {
-  re2_scanner *s = reinterpret_cast<re2_scanner *>(ptr);
+  re2_scanner *s = static_cast<re2_scanner *>(ptr);
   rb_gc_mark_movable(s->regexp);
 
   /* Text must not be movable because the StringPiece input holds a pointer
@@ -311,12 +311,12 @@ static void re2_scanner_mark(void *ptr) {
 }
 
 static void re2_scanner_compact(void *ptr) {
-  re2_scanner *s = reinterpret_cast<re2_scanner *>(ptr);
+  re2_scanner *s = static_cast<re2_scanner *>(ptr);
   s->regexp = rb_gc_location(s->regexp);
 }
 
 static void re2_scanner_free(void *ptr) {
-  re2_scanner *s = reinterpret_cast<re2_scanner *>(ptr);
+  re2_scanner *s = static_cast<re2_scanner *>(ptr);
   if (s->input) {
     delete s->input;
   }
@@ -324,7 +324,7 @@ static void re2_scanner_free(void *ptr) {
 }
 
 static size_t re2_scanner_memsize(const void *ptr) {
-  const re2_scanner *s = reinterpret_cast<const re2_scanner *>(ptr);
+  const re2_scanner *s = static_cast<const re2_scanner *>(ptr);
   size_t size = sizeof(*s);
   if (s->input) {
     size += sizeof(*s->input);
@@ -349,7 +349,7 @@ static const rb_data_type_t re2_scanner_data_type = {
 };
 
 static void re2_regexp_free(void *ptr) {
-  re2_pattern *p = reinterpret_cast<re2_pattern *>(ptr);
+  re2_pattern *p = static_cast<re2_pattern *>(ptr);
   if (p->pattern) {
     delete p->pattern;
   }
@@ -357,7 +357,7 @@ static void re2_regexp_free(void *ptr) {
 }
 
 static size_t re2_regexp_memsize(const void *ptr) {
-  const re2_pattern *p = reinterpret_cast<const re2_pattern *>(ptr);
+  const re2_pattern *p = static_cast<const re2_pattern *>(ptr);
   size_t size = sizeof(*p);
   if (p->pattern) {
     size += sizeof(*p->pattern);
@@ -2380,7 +2380,7 @@ static VALUE re2_escape(VALUE, VALUE unquoted) {
 }
 
 static void re2_set_free(void *ptr) {
-  re2_set *s = reinterpret_cast<re2_set *>(ptr);
+  re2_set *s = static_cast<re2_set *>(ptr);
   if (s->set) {
     delete s->set;
   }
@@ -2388,7 +2388,7 @@ static void re2_set_free(void *ptr) {
 }
 
 static size_t re2_set_memsize(const void *ptr) {
-  const re2_set *s = reinterpret_cast<const re2_set *>(ptr);
+  const re2_set *s = static_cast<const re2_set *>(ptr);
   size_t size = sizeof(*s);
   if (s->set) {
     size += sizeof(*s->set);

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -122,6 +122,53 @@ static void *nogvl_set_match(void *ptr) {
   return nullptr;
 }
 
+struct nogvl_replace_arg {
+  std::string *str;
+  const RE2 *pattern;
+  re2::StringPiece string_pattern;
+  re2::StringPiece rewrite;
+};
+
+static void *nogvl_replace(void *ptr) {
+  auto *arg = static_cast<nogvl_replace_arg *>(ptr);
+  if (arg->pattern) {
+    RE2::Replace(arg->str, *arg->pattern, arg->rewrite);
+  } else {
+    RE2::Replace(arg->str, arg->string_pattern, arg->rewrite);
+  }
+  return nullptr;
+}
+
+static void *nogvl_global_replace(void *ptr) {
+  auto *arg = static_cast<nogvl_replace_arg *>(ptr);
+  if (arg->pattern) {
+    RE2::GlobalReplace(arg->str, *arg->pattern, arg->rewrite);
+  } else {
+    RE2::GlobalReplace(arg->str, arg->string_pattern, arg->rewrite);
+  }
+  return nullptr;
+}
+
+struct nogvl_extract_arg {
+  re2::StringPiece text;
+  const RE2 *pattern;
+  re2::StringPiece string_pattern;
+  re2::StringPiece rewrite;
+  std::string *out;
+  bool extracted;
+};
+
+static void *nogvl_extract(void *ptr) {
+  auto *arg = static_cast<nogvl_extract_arg *>(ptr);
+  if (arg->pattern) {
+    arg->extracted = RE2::Extract(arg->text, *arg->pattern,
+        arg->rewrite, arg->out);
+  } else {
+    arg->extracted = RE2::Extract(arg->text, RE2(arg->string_pattern),
+        arg->rewrite, arg->out);
+  }
+  return nullptr;
+}
 
 VALUE re2_mRE2, re2_cRegexp, re2_cMatchData, re2_cScanner, re2_cSet,
       re2_eSetMatchError, re2_eSetUnsupportedError, re2_eRegexpUnsupportedError;
@@ -2124,24 +2171,36 @@ static VALUE re2_replace(VALUE, VALUE str, VALUE pattern,
   StringValue(rewrite);
   rewrite = rb_str_new_frozen(rewrite);
 
-  /* Take a copy of str so it can be modified in-place by
-   * RE2::Replace.
-   */
+  /* Take a copy of str so it can be modified in-place by RE2::Replace. */
   std::string str_as_string(RSTRING_PTR(str), RSTRING_LEN(str));
 
-  /* Do the replacement. */
+  nogvl_replace_arg arg;
+  arg.str = &str_as_string;
   if (p) {
-    RE2::Replace(&str_as_string, *p->pattern,
-        re2::StringPiece(RSTRING_PTR(rewrite), RSTRING_LEN(rewrite)));
+    arg.pattern = p->pattern;
+  } else {
+    arg.pattern = nullptr;
+    arg.string_pattern = re2::StringPiece(
+        RSTRING_PTR(pattern), RSTRING_LEN(pattern));
+  }
+  arg.rewrite = re2::StringPiece(
+      RSTRING_PTR(rewrite), RSTRING_LEN(rewrite));
 
+#ifdef _WIN32
+  nogvl_replace(&arg);
+#else
+  rb_thread_call_without_gvl(nogvl_replace, &arg, NULL, NULL);
+#endif
+
+  RB_GC_GUARD(rewrite);
+  RB_GC_GUARD(pattern);
+
+  if (p) {
     return encoded_str_new(str_as_string.data(), str_as_string.size(),
         p->pattern->options().encoding());
   } else {
-    RE2::Replace(&str_as_string,
-        re2::StringPiece(RSTRING_PTR(pattern), RSTRING_LEN(pattern)),
-        re2::StringPiece(RSTRING_PTR(rewrite), RSTRING_LEN(rewrite)));
-
-    return encoded_str_new(str_as_string.data(), str_as_string.size(), RE2::Options::EncodingUTF8);
+    return encoded_str_new(str_as_string.data(), str_as_string.size(),
+        RE2::Options::EncodingUTF8);
   }
 }
 
@@ -2189,19 +2248,33 @@ static VALUE re2_global_replace(VALUE, VALUE str, VALUE pattern,
    */
   std::string str_as_string(RSTRING_PTR(str), RSTRING_LEN(str));
 
-  /* Do the replacement. */
+  nogvl_replace_arg arg;
+  arg.str = &str_as_string;
   if (p) {
-    RE2::GlobalReplace(&str_as_string, *p->pattern,
-        re2::StringPiece(RSTRING_PTR(rewrite), RSTRING_LEN(rewrite)));
+    arg.pattern = p->pattern;
+  } else {
+    arg.pattern = nullptr;
+    arg.string_pattern = re2::StringPiece(
+        RSTRING_PTR(pattern), RSTRING_LEN(pattern));
+  }
+  arg.rewrite = re2::StringPiece(
+      RSTRING_PTR(rewrite), RSTRING_LEN(rewrite));
 
+#ifdef _WIN32
+  nogvl_global_replace(&arg);
+#else
+  rb_thread_call_without_gvl(nogvl_global_replace, &arg, NULL, NULL);
+#endif
+
+  RB_GC_GUARD(rewrite);
+  RB_GC_GUARD(pattern);
+
+  if (p) {
     return encoded_str_new(str_as_string.data(), str_as_string.size(),
         p->pattern->options().encoding());
   } else {
-    RE2::GlobalReplace(&str_as_string,
-        re2::StringPiece(RSTRING_PTR(pattern), RSTRING_LEN(pattern)),
-        re2::StringPiece(RSTRING_PTR(rewrite), RSTRING_LEN(rewrite)));
-
-    return encoded_str_new(str_as_string.data(), str_as_string.size(), RE2::Options::EncodingUTF8);
+    return encoded_str_new(str_as_string.data(), str_as_string.size(),
+        RE2::Options::EncodingUTF8);
   }
 }
 
@@ -2247,34 +2320,37 @@ static VALUE re2_extract(VALUE, VALUE text, VALUE pattern,
   rewrite = rb_str_new_frozen(rewrite);
 
   std::string out;
-  bool extracted;
 
+  nogvl_extract_arg arg;
+  arg.text = re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text));
   if (p) {
-    extracted = RE2::Extract(
-        re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text)),
-        *p->pattern,
-        re2::StringPiece(RSTRING_PTR(rewrite), RSTRING_LEN(rewrite)),
-        &out);
-
-    if (extracted) {
-      return encoded_str_new(out.data(), out.size(),
-          p->pattern->options().encoding());
-    } else {
-      return Qnil;
-    }
+    arg.pattern = p->pattern;
   } else {
-    extracted = RE2::Extract(
-        re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text)),
-        RE2(re2::StringPiece(RSTRING_PTR(pattern), RSTRING_LEN(pattern))),
-        re2::StringPiece(RSTRING_PTR(rewrite), RSTRING_LEN(rewrite)),
-        &out);
+    arg.pattern = nullptr;
+    arg.string_pattern = re2::StringPiece(
+        RSTRING_PTR(pattern), RSTRING_LEN(pattern));
+  }
+  arg.rewrite = re2::StringPiece(
+      RSTRING_PTR(rewrite), RSTRING_LEN(rewrite));
+  arg.out = &out;
+  arg.extracted = false;
 
-    if (extracted) {
-      return encoded_str_new(out.data(), out.size(),
-          RE2::Options::EncodingUTF8);
-    } else {
-      return Qnil;
-    }
+#ifdef _WIN32
+  nogvl_extract(&arg);
+#else
+  rb_thread_call_without_gvl(nogvl_extract, &arg, NULL, NULL);
+#endif
+
+  RB_GC_GUARD(text);
+  RB_GC_GUARD(rewrite);
+  RB_GC_GUARD(pattern);
+
+  if (arg.extracted) {
+    return encoded_str_new(out.data(), out.size(),
+        p ? p->pattern->options().encoding()
+          : RE2::Options::EncodingUTF8);
+  } else {
+    return Qnil;
   }
 }
 

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -1329,6 +1329,8 @@ static VALUE re2_regexp_initialize(int argc, VALUE *argv, VALUE self) {
 
   TypedData_Get_Struct(self, re2_pattern, &re2_regexp_data_type, p);
 
+  rb_check_frozen(self);
+
   if (p->pattern) {
     delete p->pattern;
     p->pattern = nullptr;
@@ -1349,6 +1351,8 @@ static VALUE re2_regexp_initialize(int argc, VALUE *argv, VALUE self) {
     rb_raise(rb_eNoMemError, "not enough memory to allocate RE2 object");
   }
 
+  rb_obj_freeze(self);
+
   return self;
 }
 
@@ -1357,6 +1361,8 @@ static VALUE re2_regexp_initialize_copy(VALUE self, VALUE other) {
   re2_pattern *other_p = unwrap_re2_regexp(other);
 
   TypedData_Get_Struct(self, re2_pattern, &re2_regexp_data_type, self_p);
+
+  rb_check_frozen(self);
 
   if (self_p->pattern) {
     delete self_p->pattern;
@@ -1368,6 +1374,8 @@ static VALUE re2_regexp_initialize_copy(VALUE self, VALUE other) {
   if (self_p->pattern == nullptr) {
     rb_raise(rb_eNoMemError, "not enough memory to allocate RE2 object");
   }
+
+  rb_obj_freeze(self);
 
   return self;
 }
@@ -1833,8 +1841,9 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, const VALUE self) {
 
   rb_scan_args(argc, argv, "11", &text, &options);
 
-  /* Ensure text is a string. */
+  /* Coerce and freeze text to prevent mutation. */
   StringValue(text);
+  text = rb_str_new_frozen(text);
 
   p = unwrap_re2_regexp(self);
 
@@ -1932,7 +1941,6 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, const VALUE self) {
 #endif
 
   if (n == 0) {
-    text = rb_str_new_frozen(text);
     bool matched = re2_match_without_gvl(
         p->pattern, text, startpos, endpos, anchor, 0, 0);
     RB_GC_GUARD(text);
@@ -1945,8 +1953,6 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, const VALUE self) {
 
     /* Because match returns the whole match as well. */
     n += 1;
-
-    text = rb_str_new_frozen(text);
 
     re2::StringPiece *matches = new(std::nothrow) re2::StringPiece[n];
     if (matches == nullptr) {
@@ -1986,12 +1992,10 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, const VALUE self) {
  * @raise [TypeError] if text cannot be coerced to a `String`
  */
 static VALUE re2_regexp_match_p(const VALUE self, VALUE text) {
-  /* Ensure text is a string. */
   StringValue(text);
+  text = rb_str_new_frozen(text);
 
   re2_pattern *p = unwrap_re2_regexp(self);
-
-  text = rb_str_new_frozen(text);
   bool matched = re2_match_without_gvl(
       p->pattern, text, 0, RSTRING_LEN(text), RE2::UNANCHORED, 0, 0);
   RB_GC_GUARD(text);
@@ -2009,12 +2013,10 @@ static VALUE re2_regexp_match_p(const VALUE self, VALUE text) {
  * @raise [TypeError] if text cannot be coerced to a `String`
  */
 static VALUE re2_regexp_full_match_p(const VALUE self, VALUE text) {
-  /* Ensure text is a string. */
   StringValue(text);
+  text = rb_str_new_frozen(text);
 
   re2_pattern *p = unwrap_re2_regexp(self);
-
-  text = rb_str_new_frozen(text);
   bool matched = re2_match_without_gvl(
       p->pattern, text, 0, RSTRING_LEN(text), RE2::ANCHOR_BOTH, 0, 0);
   RB_GC_GUARD(text);
@@ -2035,8 +2037,8 @@ static VALUE re2_regexp_full_match_p(const VALUE self, VALUE text) {
  *   #=> #<RE2::Scanner:0x0000000000000001>
  */
 static VALUE re2_regexp_scan(const VALUE self, VALUE text) {
-  /* Ensure text is a string. */
   StringValue(text);
+  text = rb_str_new_frozen(text);
 
   re2_pattern *p = unwrap_re2_regexp(self);
   re2_scanner *c;
@@ -2044,7 +2046,7 @@ static VALUE re2_regexp_scan(const VALUE self, VALUE text) {
   TypedData_Get_Struct(scanner, re2_scanner, &re2_scanner_data_type, c);
 
   RB_OBJ_WRITE(scanner, &c->regexp, self);
-  RB_OBJ_WRITE(scanner, &c->text, rb_str_new_frozen(text));
+  RB_OBJ_WRITE(scanner, &c->text, text);
   c->input = new(std::nothrow) re2::StringPiece(
       RSTRING_PTR(c->text), RSTRING_LEN(c->text));
   if (c->input == nullptr) {
@@ -2107,16 +2109,20 @@ static VALUE re2_replace(VALUE, VALUE str, VALUE pattern,
     VALUE rewrite) {
   re2_pattern *p = nullptr;
 
-  /* Coerce all arguments before any C++ allocations so that any Ruby
-   * exceptions (via longjmp) cannot bypass C++ destructors and leak memory.
+  /* Coerce and freeze all arguments before any C++ allocations so that any
+   * Ruby exceptions (via longjmp) cannot bypass C++ destructors and leak
+   * memory, and later coercions cannot mutate earlier strings.
    */
   StringValue(str);
+  str = rb_str_new_frozen(str);
   if (rb_obj_is_kind_of(pattern, re2_cRegexp)) {
     p = unwrap_re2_regexp(pattern);
   } else {
     StringValue(pattern);
+    pattern = rb_str_new_frozen(pattern);
   }
   StringValue(rewrite);
+  rewrite = rb_str_new_frozen(rewrite);
 
   /* Take a copy of str so it can be modified in-place by
    * RE2::Replace.
@@ -2163,16 +2169,20 @@ static VALUE re2_global_replace(VALUE, VALUE str, VALUE pattern,
                                VALUE rewrite) {
   re2_pattern *p = nullptr;
 
-  /* Coerce all arguments before any C++ allocations so that any Ruby
-   * exceptions (via longjmp) cannot bypass C++ destructors and leak memory.
+  /* Coerce and freeze all arguments before any C++ allocations so that any
+   * Ruby exceptions (via longjmp) cannot bypass C++ destructors and leak
+   * memory, and later coercions cannot mutate earlier strings.
    */
   StringValue(str);
+  str = rb_str_new_frozen(str);
   if (rb_obj_is_kind_of(pattern, re2_cRegexp)) {
     p = unwrap_re2_regexp(pattern);
   } else {
     StringValue(pattern);
+    pattern = rb_str_new_frozen(pattern);
   }
   StringValue(rewrite);
+  rewrite = rb_str_new_frozen(rewrite);
 
   /* Take a copy of str so it can be modified in-place by
    * RE2::GlobalReplace.
@@ -2221,16 +2231,20 @@ static VALUE re2_extract(VALUE, VALUE text, VALUE pattern,
     VALUE rewrite) {
   re2_pattern *p = nullptr;
 
-  /* Coerce all arguments before any C++ allocations so that any Ruby
-   * exceptions (via longjmp) cannot bypass C++ destructors and leak memory.
+  /* Coerce and freeze all arguments before any C++ allocations so that any
+   * Ruby exceptions (via longjmp) cannot bypass C++ destructors and leak
+   * memory, and later coercions cannot mutate earlier strings.
    */
   StringValue(text);
+  text = rb_str_new_frozen(text);
   if (rb_obj_is_kind_of(pattern, re2_cRegexp)) {
     p = unwrap_re2_regexp(pattern);
   } else {
     StringValue(pattern);
+    pattern = rb_str_new_frozen(pattern);
   }
   StringValue(rewrite);
+  rewrite = rb_str_new_frozen(rewrite);
 
   std::string out;
   bool extracted;
@@ -2411,6 +2425,8 @@ static VALUE re2_set_initialize(int argc, VALUE *argv, VALUE self) {
     parse_re2_options(&re2_options, options);
   }
 
+  rb_check_frozen(self);
+
   if (s->set) {
     delete s->set;
     s->set = nullptr;
@@ -2441,6 +2457,7 @@ static VALUE re2_set_add(VALUE self, VALUE pattern) {
   StringValue(pattern);
 
   re2_set *s = unwrap_re2_set(self);
+  rb_check_frozen(self);
 
   int index;
   VALUE msg;
@@ -2472,8 +2489,15 @@ static VALUE re2_set_add(VALUE self, VALUE pattern) {
  */
 static VALUE re2_set_compile(VALUE self) {
   re2_set *s = unwrap_re2_set(self);
+  rb_check_frozen(self);
 
-  return BOOL2RUBY(s->set->Compile());
+  bool compiled = s->set->Compile();
+
+  if (compiled) {
+    rb_obj_freeze(self);
+  }
+
+  return BOOL2RUBY(compiled);
 }
 
 /*
@@ -2570,6 +2594,8 @@ static VALUE re2_set_match(int argc, VALUE *argv, const VALUE self) {
   rb_scan_args(argc, argv, "11", &str, &options);
 
   StringValue(str);
+  str = rb_str_new_frozen(str);
+
   re2_set *s = unwrap_re2_set(self);
 
   if (RTEST(options)) {
@@ -2582,8 +2608,6 @@ static VALUE re2_set_match(int argc, VALUE *argv, const VALUE self) {
   }
 
   std::vector<int> v;
-
-  str = rb_str_new_frozen(str);
 
   if (raise_exception) {
 #ifdef HAVE_ERROR_INFO_ARGUMENT

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -19,6 +19,7 @@
 #include <re2/set.h>
 #include <ruby.h>
 #include <ruby/encoding.h>
+#include <ruby/thread.h>
 
 #define BOOL2RUBY(v) (v ? Qtrue : Qfalse)
 
@@ -42,6 +43,60 @@ typedef struct {
 typedef struct {
   RE2::Set *set;
 } re2_set;
+
+struct nogvl_match_arg {
+  const RE2 *pattern;
+  re2::StringPiece text;
+  size_t startpos;
+  size_t endpos;
+  RE2::Anchor anchor;
+  re2::StringPiece *matches;
+  int n;
+  bool matched;
+};
+
+static void *nogvl_match(void *ptr) {
+  auto *arg = static_cast<nogvl_match_arg *>(ptr);
+#ifdef HAVE_ENDPOS_ARGUMENT
+  arg->matched = arg->pattern->Match(
+      arg->text, arg->startpos, arg->endpos,
+      arg->anchor, arg->matches, arg->n);
+#else
+  arg->matched = arg->pattern->Match(
+      arg->text, arg->startpos,
+      arg->anchor, arg->matches, arg->n);
+#endif
+  return nullptr;
+}
+
+static bool re2_match_without_gvl(
+    const RE2 *pattern, VALUE text, size_t startpos, size_t endpos,
+    RE2::Anchor anchor, re2::StringPiece *matches, int n) {
+  nogvl_match_arg arg;
+  arg.pattern = pattern;
+  arg.text = re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text));
+  arg.startpos = startpos;
+  arg.endpos = endpos;
+  arg.anchor = anchor;
+  arg.matches = matches;
+  arg.n = n;
+  arg.matched = false;
+
+  /* Abseil's synchronization primitives (SRWLOCK, SleepConditionVariableSRW)
+   * are incompatible with Ruby's Win32 Mutex-based GVL, causing
+   * WAIT_ABANDONED crashes when multiple threads match concurrently.
+   */
+#ifdef _WIN32
+  nogvl_match(&arg);
+#else
+  /* No unblocking function is needed: RE2 matching is CPU-bound computation,
+   * not a blocking system call, so a signal cannot safely interrupt it.
+   */
+  rb_thread_call_without_gvl(nogvl_match, &arg, NULL, NULL);
+#endif
+
+  return arg.matched;
+}
 
 VALUE re2_mRE2, re2_cRegexp, re2_cMatchData, re2_cScanner, re2_cSet,
       re2_eSetMatchError, re2_eSetUnsupportedError, re2_eRegexpUnsupportedError;
@@ -1852,15 +1907,11 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, const VALUE self) {
 #endif
 
   if (n == 0) {
-#ifdef HAVE_ENDPOS_ARGUMENT
-    bool matched = p->pattern->Match(
-        re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text)),
-        startpos, endpos, anchor, 0, 0);
-#else
-    bool matched = p->pattern->Match(
-        re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text)),
-        startpos, anchor, 0, 0);
-#endif
+    text = rb_str_new_frozen(text);
+    bool matched = re2_match_without_gvl(
+        p->pattern, text, startpos, endpos, anchor, 0, 0);
+    RB_GC_GUARD(text);
+
     return BOOL2RUBY(matched);
   } else {
     if (n == INT_MAX) {
@@ -1870,23 +1921,18 @@ static VALUE re2_regexp_match(int argc, VALUE *argv, const VALUE self) {
     /* Because match returns the whole match as well. */
     n += 1;
 
+    text = rb_str_new_frozen(text);
+
     re2::StringPiece *matches = new(std::nothrow) re2::StringPiece[n];
     if (matches == nullptr) {
       rb_raise(rb_eNoMemError,
                "not enough memory to allocate StringPieces for matches");
     }
 
-    text = rb_str_new_frozen(text);
+    bool matched = re2_match_without_gvl(
+        p->pattern, text, startpos, endpos, anchor, matches, n);
+    RB_GC_GUARD(text);
 
-#ifdef HAVE_ENDPOS_ARGUMENT
-    bool matched = p->pattern->Match(
-        re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text)),
-        startpos, endpos, anchor, matches, n);
-#else
-    bool matched = p->pattern->Match(
-        re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text)),
-        startpos, anchor, matches, n);
-#endif
     if (matched) {
       VALUE matchdata = rb_class_new_instance(0, 0, re2_cMatchData);
       TypedData_Get_Struct(matchdata, re2_matchdata, &re2_matchdata_data_type, m);
@@ -1920,8 +1966,12 @@ static VALUE re2_regexp_match_p(const VALUE self, VALUE text) {
 
   re2_pattern *p = unwrap_re2_regexp(self);
 
-  return BOOL2RUBY(RE2::PartialMatch(
-        re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text)), *p->pattern));
+  text = rb_str_new_frozen(text);
+  bool matched = re2_match_without_gvl(
+      p->pattern, text, 0, RSTRING_LEN(text), RE2::UNANCHORED, 0, 0);
+  RB_GC_GUARD(text);
+
+  return BOOL2RUBY(matched);
 }
 
 /*
@@ -1939,8 +1989,12 @@ static VALUE re2_regexp_full_match_p(const VALUE self, VALUE text) {
 
   re2_pattern *p = unwrap_re2_regexp(self);
 
-  return BOOL2RUBY(RE2::FullMatch(
-        re2::StringPiece(RSTRING_PTR(text), RSTRING_LEN(text)), *p->pattern));
+  text = rb_str_new_frozen(text);
+  bool matched = re2_match_without_gvl(
+      p->pattern, text, 0, RSTRING_LEN(text), RE2::ANCHOR_BOTH, 0, 0);
+  RB_GC_GUARD(text);
+
+  return BOOL2RUBY(matched);
 }
 
 /*

--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -98,6 +98,31 @@ static bool re2_match_without_gvl(
   return arg.matched;
 }
 
+struct nogvl_set_match_arg {
+  const RE2::Set *set;
+  re2::StringPiece text;
+  std::vector<int> *v;
+#ifdef HAVE_ERROR_INFO_ARGUMENT
+  RE2::Set::ErrorInfo *error_info;
+#endif
+  bool matched;
+};
+
+static void *nogvl_set_match(void *ptr) {
+  auto *arg = static_cast<nogvl_set_match_arg *>(ptr);
+#ifdef HAVE_ERROR_INFO_ARGUMENT
+  if (arg->error_info) {
+    arg->matched = arg->set->Match(arg->text, arg->v, arg->error_info);
+  } else {
+    arg->matched = arg->set->Match(arg->text, arg->v);
+  }
+#else
+  arg->matched = arg->set->Match(arg->text, arg->v);
+#endif
+  return nullptr;
+}
+
+
 VALUE re2_mRE2, re2_cRegexp, re2_cMatchData, re2_cScanner, re2_cSet,
       re2_eSetMatchError, re2_eSetUnsupportedError, re2_eRegexpUnsupportedError;
 
@@ -2558,11 +2583,26 @@ static VALUE re2_set_match(int argc, VALUE *argv, const VALUE self) {
 
   std::vector<int> v;
 
+  str = rb_str_new_frozen(str);
+
   if (raise_exception) {
 #ifdef HAVE_ERROR_INFO_ARGUMENT
     RE2::Set::ErrorInfo e;
-    bool match_failed = !s->set->Match(
-        re2::StringPiece(RSTRING_PTR(str), RSTRING_LEN(str)), &v, &e);
+    nogvl_set_match_arg arg;
+    arg.set = s->set;
+    arg.text = re2::StringPiece(RSTRING_PTR(str), RSTRING_LEN(str));
+    arg.v = &v;
+    arg.error_info = &e;
+    arg.matched = false;
+
+#ifdef _WIN32
+    nogvl_set_match(&arg);
+#else
+    rb_thread_call_without_gvl(nogvl_set_match, &arg, NULL, NULL);
+#endif
+    RB_GC_GUARD(str);
+
+    bool match_failed = !arg.matched;
     VALUE result = rb_ary_new2(v.size());
 
     if (match_failed) {
@@ -2589,11 +2629,25 @@ static VALUE re2_set_match(int argc, VALUE *argv, const VALUE self) {
     rb_raise(re2_eSetUnsupportedError, "current version of RE2::Set::Match() does not output error information, :exception option can only be set to false");
 #endif
   } else {
-    bool matched = s->set->Match(
-        re2::StringPiece(RSTRING_PTR(str), RSTRING_LEN(str)), &v);
+    nogvl_set_match_arg arg;
+    arg.set = s->set;
+    arg.text = re2::StringPiece(RSTRING_PTR(str), RSTRING_LEN(str));
+    arg.v = &v;
+#ifdef HAVE_ERROR_INFO_ARGUMENT
+    arg.error_info = nullptr;
+#endif
+    arg.matched = false;
+
+#ifdef _WIN32
+    nogvl_set_match(&arg);
+#else
+    rb_thread_call_without_gvl(nogvl_set_match, &arg, NULL, NULL);
+#endif
+    RB_GC_GUARD(str);
+
     VALUE result = rb_ary_new2(v.size());
 
-    if (matched) {
+    if (arg.matched) {
       for (int index : v) {
         rb_ary_push(result, INT2FIX(index));
       }

--- a/spec/re2/regexp_spec.rb
+++ b/spec/re2/regexp_spec.rb
@@ -769,6 +769,16 @@ RSpec.describe RE2::Regexp do
     it "raises an error when called on an uninitialized object" do
       expect { described_class.allocate.match("test") }.to raise_error(TypeError, /uninitialized RE2::Regexp/)
     end
+
+    it "can be run concurrently" do
+      re = RE2::Regexp.new('(\w+)\s(\w+)')
+
+      threads = 10.times.map do
+        Thread.new { re.match("one two").values_at(1, 2) }
+      end
+
+      expect(threads.map(&:value)).to all(eq(["one", "two"]))
+    end
   end
 
   describe "#match?" do
@@ -793,6 +803,16 @@ RSpec.describe RE2::Regexp do
 
     it "raises an error when called on an uninitialized object" do
       expect { described_class.allocate.match?("test") }.to raise_error(TypeError, /uninitialized RE2::Regexp/)
+    end
+
+    it "can be run concurrently" do
+      re = RE2::Regexp.new('(\w+)\s(\w+)')
+
+      threads = 10.times.map do
+        Thread.new { re.match?("one two") }
+      end
+
+      expect(threads.map(&:value)).to all(eq(true))
     end
   end
 
@@ -825,6 +845,16 @@ RSpec.describe RE2::Regexp do
 
     it "raises an error when called on an uninitialized object" do
       expect { described_class.allocate.partial_match?("test") }.to raise_error(TypeError, /uninitialized RE2::Regexp/)
+    end
+
+    it "can be run concurrently" do
+      re = RE2::Regexp.new('(\d+)')
+
+      threads = 10.times.map do
+        Thread.new { re.partial_match?("alice 123") }
+      end
+
+      expect(threads.map(&:value)).to all(eq(true))
     end
   end
 
@@ -914,6 +944,16 @@ RSpec.describe RE2::Regexp do
 
     it "raises an error when called on an uninitialized object" do
       expect { described_class.allocate.full_match?("test") }.to raise_error(TypeError, /uninitialized RE2::Regexp/)
+    end
+
+    it "can be run concurrently" do
+      re = RE2::Regexp.new('(\w+) (\d+)')
+
+      threads = 10.times.map do
+        Thread.new { re.full_match?("alice 123") }
+      end
+
+      expect(threads.map(&:value)).to all(eq(true))
     end
   end
 

--- a/spec/re2/regexp_spec.rb
+++ b/spec/re2/regexp_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe RE2::Regexp do
 
       expect(re).to be_a(RE2::Regexp)
     end
+
+    it "returns a frozen object" do
+      expect(RE2::Regexp.new('woo')).to be_frozen
+    end
+
+    it "cannot be re-initialized" do
+      re = RE2::Regexp.new('woo')
+
+      expect { re.send(:initialize, 'bar') }.to raise_error(FrozenError)
+    end
   end
 
   describe "#dup" do
@@ -70,6 +80,13 @@ RSpec.describe RE2::Regexp do
       expect(copy).to_not be_case_sensitive
     end
 
+    it "returns a frozen copy" do
+      re = described_class.new('(\d+)')
+      copy = re.dup
+
+      expect(copy).to be_frozen
+    end
+
     it "raises an error when called on an uninitialized object" do
       expect { described_class.allocate.dup }.to raise_error(TypeError, /uninitialized RE2::Regexp/)
     end
@@ -81,6 +98,13 @@ RSpec.describe RE2::Regexp do
       copy = re.clone
 
       expect(copy.to_s).to eq('woo')
+    end
+
+    it "returns a frozen copy" do
+      re = described_class.new('woo')
+      copy = re.clone
+
+      expect(copy).to be_frozen
     end
 
     it "raises an error when called on an uninitialized object" do

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -84,14 +84,12 @@ RSpec.describe RE2::Set do
       expect { set.add("(?P<#{'o' * 200}") }.to raise_error(ArgumentError, "str rejected by RE2::Set->Add(): invalid named capture group: (?P<oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo")
     end
 
-    it "raises an error if called after #compile" do
+    it "raises a FrozenError if called after #compile" do
       set = RE2::Set.new(:unanchored, log_errors: false)
       set.add("abc")
       set.compile
 
-      silence_stderr do
-        expect { set.add("def") }.to raise_error(ArgumentError)
-      end
+      expect { set.add("def") }.to raise_error(FrozenError)
     end
 
     it "raises an error if given a pattern that can't be coerced to a String" do
@@ -119,6 +117,29 @@ RSpec.describe RE2::Set do
       set.add("ghi")
 
       expect(set.compile).to be_truthy
+    end
+
+    it "freezes the set on successful compilation" do
+      set = RE2::Set.new
+      set.add("abc")
+      set.compile
+
+      expect(set).to be_frozen
+    end
+
+    it "is not frozen before compilation" do
+      set = RE2::Set.new
+      set.add("abc")
+
+      expect(set).to_not be_frozen
+    end
+
+    it "cannot be re-initialized after compilation" do
+      set = RE2::Set.new
+      set.add("abc")
+      set.compile
+
+      expect { set.send(:initialize) }.to raise_error(FrozenError)
     end
 
     it "raises an error when called on an uninitialized object" do

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -226,6 +226,20 @@ RSpec.describe RE2::Set do
     it "raises an error when called on an uninitialized object" do
       expect { described_class.allocate.match("foo") }.to raise_error(TypeError, /uninitialized RE2::Set/)
     end
+
+    it "can be run concurrently" do
+      set = RE2::Set.new
+      set.add("abc")
+      set.add("def")
+      set.add("ghi")
+      set.compile
+
+      threads = 10.times.map do
+        Thread.new { set.match("abcdefghi", exception: false) }
+      end
+
+      expect(threads.map(&:value)).to all(eq([0, 1, 2]))
+    end
   end
 
   describe "#size" do

--- a/spec/re2_spec.rb
+++ b/spec/re2_spec.rb
@@ -93,6 +93,26 @@ RSpec.describe RE2 do
     it "raises a Type Error for a replacement that can't be converted to String" do
       expect { RE2.replace("woo", "oo", 0) }.to raise_error(TypeError)
     end
+
+    it "can be run concurrently with the same RE2::Regexp pattern" do
+      re = RE2::Regexp.new('(\w+)\s(\w+)')
+
+      threads = 10.times.map do
+        Thread.new { RE2.replace("one two", re, '\2 \1') }
+      end
+
+      expect(threads.map(&:value)).to all(eq("two one"))
+    end
+
+    it "can be run concurrently with the same string pattern" do
+      re = '(\w+)\s(\w+)'
+
+      threads = 10.times.map do
+        Thread.new { RE2.replace("one two", re, '\2 \1') }
+      end
+
+      expect(threads.map(&:value)).to all(eq("two one"))
+    end
   end
 
   describe ".Replace" do
@@ -193,6 +213,26 @@ RSpec.describe RE2 do
     it "raises a Type Error for a replacement that can't be converted to String" do
       expect { RE2.global_replace("woo", "o", 0) }.to raise_error(TypeError)
     end
+
+    it "can be run concurrently with the same RE2::Regexp pattern" do
+      re = RE2::Regexp.new('(\w+)\s(\w+)')
+
+      threads = 10.times.map do
+        Thread.new { RE2.global_replace("one two three four", re, '\2 \1') }
+      end
+
+      expect(threads.map(&:value)).to all(eq("two one four three"))
+    end
+
+    it "can be run concurrently with the same string pattern" do
+      re = '(\w+)\s(\w+)'
+
+      threads = 10.times.map do
+        Thread.new { RE2.global_replace("one two three four", re, '\2 \1') }
+      end
+
+      expect(threads.map(&:value)).to all(eq("two one four three"))
+    end
   end
 
   describe ".GlobalReplace" do
@@ -280,6 +320,26 @@ RSpec.describe RE2 do
 
     it "raises a Type Error for a rewrite that can't be converted to String" do
       expect { RE2.extract("woo", '(\w+)', 0) }.to raise_error(TypeError)
+    end
+
+    it "can be run concurrently with the same RE2::Regexp pattern" do
+      re = RE2::Regexp.new('(\w+)@(\w+)')
+
+      threads = 10.times.map do
+        Thread.new { RE2.extract("alice@example", re, '\2-\1') }
+      end
+
+      expect(threads.map(&:value)).to all(eq("example-alice"))
+    end
+
+    it "can be run concurrently with the same string pattern" do
+      re = '(\w+)@(\w+)'
+
+      threads = 10.times.map do
+        Thread.new { RE2.extract("alice@example", re, '\2-\1') }
+      end
+
+      expect(threads.map(&:value)).to all(eq("example-alice"))
     end
   end
 


### PR DESCRIPTION
Like the official RE2 Python bindings, release the Ruby Global VM Lock
when performing matches so work on other threads can continue.

Note that Abseil's synchronization primitives (SRWLOCK and
SleepConditionVariableSRW) are incompatible with Ruby's Win32
Mutex-based GVL, causing WAIT_ABANDONED crashes when multiple threads
match concurrently so the GVL is _not_ released on Windows.