### PR TITLE
Fix use-after-free when re-initializing Set

### DIFF
--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -2503,9 +2503,12 @@ static VALUE re2_set_initialize(int argc, VALUE *argv, VALUE self) {
 
   rb_check_frozen(self);
 
+  /* Prevent re-initialisation: #match releases the GVL while holding a
+   * pointer to s->set, so replacing s->set from another thread would free
+   * the object out from under a concurrent match.
+   */
   if (s->set) {
-    delete s->set;
-    s->set = nullptr;
+    rb_raise(rb_eTypeError, "already initialized RE2::Set");
   }
 
   s->set = new(std::nothrow) RE2::Set(re2_options, re2_anchor);

--- a/spec/re2/set_spec.rb
+++ b/spec/re2/set_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe RE2::Set do
         "anchor should be one of: :unanchored, :anchor_start, :anchor_both"
       )
     end
+
+    it "cannot be re-initialized before compilation" do
+      set = RE2::Set.new
+      set.add("abc")
+
+      expect { set.send(:initialize) }.to raise_error(TypeError, /already initialized RE2::Set/)
+    end
   end
 
   describe "#dup" do


### PR DESCRIPTION
Picked up by fuzzing the gem with Ruzzy, prevent re-initialization of a Set to avoid a use-after-free when repeatedly calling match on an uncompiled Set while re-initializing it.
