### PR TITLE
Guard against copying into self

### DIFF
--- a/ext/re2/re2.cc
+++ b/ext/re2/re2.cc
@@ -523,6 +523,8 @@ static VALUE re2_scanner_rewind(VALUE self) {
 }
 
 static VALUE re2_scanner_initialize_copy(VALUE self, VALUE other) {
+  if (self == other) return self;
+
   re2_scanner *self_c;
   re2_scanner *other_c = unwrap_re2_scanner(other);
 
@@ -1291,6 +1293,8 @@ static VALUE re2_matchdata_values_at(int argc, VALUE *argv, const VALUE self) {
 }
 
 static VALUE re2_matchdata_initialize_copy(VALUE self, VALUE other) {
+  if (self == other) return self;
+
   re2_matchdata *self_m;
   re2_matchdata *other_m = unwrap_re2_matchdata(other);
 

--- a/spec/re2/match_data_spec.rb
+++ b/spec/re2/match_data_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe RE2::MatchData do
     end
   end
 
+  describe "#initialize_copy" do
+    it "is a no-op when the source is the same object" do
+      md = RE2::Regexp.new('(\d+)').match("123")
+      md.send(:initialize_copy, md)
+
+      expect(md.to_a).to eq(["123", "123"])
+    end
+  end
+
   describe "#to_a" do
     it "is populated with the match and capturing groups" do
       a = RE2::Regexp.new('w(o)(o)').match('woo').to_a

--- a/spec/re2/scanner_spec.rb
+++ b/spec/re2/scanner_spec.rb
@@ -106,6 +106,15 @@ RSpec.describe RE2::Scanner do
     end
   end
 
+  describe "#initialize_copy" do
+    it "is a no-op when the source is the same object" do
+      scanner = RE2::Regexp.new('(\w+)').scan("foo bar")
+      scanner.send(:initialize_copy, scanner)
+
+      expect(scanner.scan).to eq(["foo"])
+    end
+  end
+
   describe "#scan" do
     it "returns the next array of matches", :aggregate_failures do
       r = RE2::Regexp.new('(\w+)')


### PR DESCRIPTION
Use the standard Ruby pattern of guarding against calling initialize_copy against self, see https://github.com/ruby/ruby/blob/11e3c78b61da705c783dd12fb7f158c0d256ede0/object.c#L652
